### PR TITLE
Extend CSS custom properties API for buttons

### DIFF
--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/commons.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/commons.css
@@ -30,14 +30,32 @@
   --note-caution-bg: var(--color-yellow-200);
   --note-caution-border-color: var(--color-yellow-500);
 
-  --btn-color: var(--color-blue-700);
+  --btn-color: #ffffff;
+  --btn-bg: var(--color-blue-700);
+  --btn-hover-bg: var(--color-blue-800);
+  --btn-hover-color: #ffffff;
+  --btn-focus-color: #ffffff;
+  --btn-focus-bg: var(--color-blue-800);
+  --btn-focus-border-color: var(--color-blue-900);
+
   --btn-primary-color: #ffffff;
+  --btn-primary-bg: var(--color-blue-600);
+  --btn-primary-hover-bg: var(--color-blue-800);
+  --btn-primary-hover-color: #ffffff;
+  --btn-primary-focus-color: var(--btn-primary-color);
+  --btn-primary-focus-bg: var(--btn-focus-bg);
+  --btn-primary-focus-border-color: var(--btn-focus-border-color);
+
   --btn-secondary-bg: var(--color-gray-200);
   --btn-secondary-color: var(--color-gray-800);
   --btn-secondary-border-width: 1px;
-  --btn-secondary-boder-color: var(--color-gray-300);
-
-  --btn-primary-bg: var(--color-blue-600);
+  --btn-secondary-border-color: var(--color-gray-300);
+  --btn-secondary-border-width: 1px;
+  --btn-secondary-hover-bg: var(--color-blue-800);
+  --btn-secondary-hover-color: #ffffff;
+  --btn-secondary-focus-color: var(--btn-primary-color);
+  --btn-secondary-focus-bg: var(--btn-focus-bg);
+  --btn-secondary-focus-border-color: var(--btn-focus-border-color);
 
   --btn-success-bg: var(--color-green-600);
 

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
@@ -27,6 +27,18 @@
 
 #peregrine-app .btn {
   color: var(--btn-color);
+  background-color: var(--btn-bg);
+}
+
+#peregrine-app .btn:focus {
+  color: var(--btn-focus-color);
+  background-color: var(--btn-focus-bg);
+  box-shadow: 0 0 0 3px var(--btn-focus-border-color);
+}
+
+#peregrine-app .btn:hover {
+  color: var(--btn-hover-color);
+  background: var(--btn-hover-color);
 }
 
 #peregrine-app .btn.btn-primary {
@@ -34,14 +46,34 @@
   background-color: var(--btn-primary-bg);
 }
 
-#peregrine-app .btn.btn-secondary {
-  border-width: var(--btn-secondary-border-width) !important;
+#peregrine-app .btn.btn-primary:focus {
+  color: var(--btn-primary-focus-color);
+  background-color: var(--btn-primary-focus-bg);
+  box-shadow: 0 0 0 3px var(--btn-primary-focus-border-color);
+}
+
+#peregrine-app .btn.btn-primary:hover {
+  color: var(--btn-primary-hover-color, var(--btn-hover-color, #ffffff));
+  background-color: var(--btn-primary-hover-bg);
 }
 
 #peregrine-app .btn.btn-secondary {
-  color: var(--btn-secondary-color) !important;
-  background-color: var(--btn-secondary-bg) !important;
-  border-color: var(--btn-secondary-boder-color) !important;
+  color: var(--btn-secondary-color);
+  background-color: var(--btn-secondary-bg);
+  border-color: var(--btn-secondary-border-color);
+  border-width: var(--btn-secondary-border-width);
+}
+
+#peregrine-app .btn.btn-secondary:focus {
+  color: var(--btn-secondary-focus-color);
+  background-color: var(--btn-secondary-focus-bg);
+  box-shadow: 0 0 0 3px var(--btn-secondary-focus-border-color);
+  border-color: transparent;
+}
+
+#peregrine-app .btn.btn-secondary:hover {
+  color: var(--btn-secondary-hover-color);
+  background-color: var(--btn-secondary-hover-bg);
 }
 
 #peregrine-app .btn.btn-success {


### PR DESCRIPTION
Thanks for contributing to Peregrine CMS!

**What does this implement/fix? Explain your changes.**

Extend the defaults and available custom properties to enable developers
to overwrite focus and hover styles of buttons via variables. Prevously,
some colours for the buttons came mixed up from the build.css, palette.css
and common.css.

**Does this close any currently open issues?**

No.

**Any other comments?**

This change is part of theme colour adjustments separated in it's own pull request. Yet, I'm not sure at this point which branch to target as it seems the state of the repository I got with the docker toolbox seems not to reflect the development branch. So please check the history of this PR and tell me, which branch to target. Develop seems to have an older state.

**Where has this been tested?**

*Browser (version):* Firefox 77 beta 2 (Developer Edition)

