### PR TITLE
#95 make tags wrap and have margin

### DIFF
--- a/core/src/main/java/com/themecleanflex/models/TagsModel.java
+++ b/core/src/main/java/com/themecleanflex/models/TagsModel.java
@@ -296,6 +296,12 @@ import org.apache.sling.models.annotations.Model;
               "x-form-min": 0,
               "x-form-max": 300,
               "x-form-visible": "model.fullheight != 'true'"
+            },
+            "contentname": {
+              "type": "string",
+              "x-source": "inject",
+              "x-form-label": "Content Name",
+              "x-form-type": "text"
             }
           }
         }
@@ -435,6 +441,10 @@ public class TagsModel extends AbstractComponent {
 	@Inject
 	private String bottompadding;
 
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	@Inject
+	private String contentname;
+
 
 //GEN]
 
@@ -552,6 +562,11 @@ public class TagsModel extends AbstractComponent {
 	/* {"type":"string","x-source":"inject","x-form-label":"Bottom Padding","x-form-type":"materialrange","x-form-min":0,"x-form-max":300,"x-form-visible":"model.fullheight != 'true'"} */
 	public String getBottompadding() {
 		return bottompadding;
+	}
+
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	public String getContentname() {
+		return contentname;
 	}
 
 

--- a/fragments/tags/template.html
+++ b/fragments/tags/template.html
@@ -1,4 +1,4 @@
-<div class="w-full flex items-center -mx-2">
-  <span class="font-bold ml-2 mr-4">My Tags</span>
-  <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline">Tag 1</component>
+<div class="w-full flex flex-wrap items-center -mx-2">
+  <span class="font-bold ml-2 mr-4 mb-1">My Tags</span>
+  <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline mb-1">Tag 1</component>
 </div>

--- a/fragments/tags/template.vue
+++ b/fragments/tags/template.vue
@@ -4,8 +4,8 @@
     <div class="w-full flex flex-wrap items-center -mx-2"
     v-else>
       <span class="font-bold ml-2 mr-4 mb-1" v-if="model.tagslabel">{{model.tagslabel}}</span>
-      <component class="text-white hover:text-white px-4 py-1 mx-2 mb-1 rounded-full shadow-md no-underline"
-      v-for="(item,i) in tags" :key="i" v-bind:class="{
+      <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline mb-1"
+      v-for="(item, i) in tags" :key="i" v-bind:class="{
             'bg-blue-600': model.tagcolor === &quot;blue&quot;,
             'bg-green-600': model.tagcolor === &quot;green&quot;,
             'bg-orange-600': model.tagcolor === &quot;orange&quot;,

--- a/fragments/tags/template.vue
+++ b/fragments/tags/template.vue
@@ -1,10 +1,10 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">There are no tags set for this page</div>
-    <div class="w-full flex items-center -mx-2"
+    <div class="w-full flex flex-wrap items-center -mx-2"
     v-else>
-      <span class="font-bold ml-2 mr-4" v-if="model.tagslabel">{{model.tagslabel}}</span>
-      <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline"
+      <span class="font-bold ml-2 mr-4 mb-1" v-if="model.tagslabel">{{model.tagslabel}}</span>
+      <component class="text-white hover:text-white px-4 py-1 mx-2 mb-1 rounded-full shadow-md no-underline"
       v-for="(item,i) in tags" :key="i" v-bind:class="{
             'bg-blue-600': model.tagcolor === &quot;blue&quot;,
             'bg-green-600': model.tagcolor === &quot;green&quot;,

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/tags/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/tags/dialog.json
@@ -279,6 +279,13 @@
       "visible": "model.fullheight != 'true'",
       "min": 0,
       "max": 300
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "contentname",
+      "label": "Content Name",
+      "model": "contentname"
     }
   ]
 }

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/tags/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/tags/template.vue
@@ -1,11 +1,11 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">There are no tags set for this page</div>
-    <div class="w-full flex items-center -mx-2"
+    <div class="w-full flex flex-wrap items-center -mx-2"
     v-else>
-      <span class="font-bold ml-2 mr-4" v-if="model.tagslabel">{{model.tagslabel}}</span>
-      <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline"
-      v-for="(item,i) in tags" :key="i" v-bind:class="{
+      <span class="font-bold ml-2 mr-4 mb-1" v-if="model.tagslabel">{{model.tagslabel}}</span>
+      <component class="text-white hover:text-white px-4 py-1 mx-2 rounded-full shadow-md no-underline mb-1"
+      v-for="(item, i) in tags" :key="i" v-bind:class="{
             'bg-blue-600': model.tagcolor === &quot;blue&quot;,
             'bg-green-600': model.tagcolor === &quot;green&quot;,
             'bg-orange-600': model.tagcolor === &quot;orange&quot;,


### PR DESCRIPTION
Thanks for contributing to Peregrine CMS!

What does this implement/fix? Explain your changes.

Fixes mobile styles for tags, just added class to tag container(flex-wrap) and inside elements (mb-1)

Does this close any currently open issues?

issue/95

Where has this been tested?

![image](https://user-images.githubusercontent.com/49845255/81451618-c0adcb00-9139-11ea-92da-c6cc0fe83824.png)


Top is before,
Bottom is after styling changes

Brower (version):
Chrome on MacOS