### PR TITLE
Switch from Montserrat to Inter

### DIFF
--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
@@ -11,7 +11,7 @@
     sling:resourceType="themecleanflex/components/page"
     jcr:title="themecleanflex root template"
     brand="themecleanflex"
-    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css?family=Montserrat:300%2C300i%2C400%2C400i%2C500%2C500i%2C600%2C600i%2C700%2C700i%2C900%2C900i&amp;amp;display=swap]"
+    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css2?family=Inter%3Awght%40300%3B400%3B500%3B600%3B700%3B900%26display%3Dswap]"
     prefetchDNS="[https://www.youtube.com,https://s.ytimg.com,https://www.google.com,https://fonts.gstatic.com,https://www.youtube-nocookie.com]"/>
 
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
@@ -10,7 +10,7 @@
     jcr:primaryType="per:PageContent"
     sling:resourceType="themecleanflex/components/page"
     jcr:title="themecleanflex root template"
-    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css2?family=Inter%3Awght%40300%3B400%3B500%3B600%3B700%3B900%26display%3Dswap]"
+    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css?family=Inter:wght@300;400;500;600;700;900&amp;display=swap]"
     prefetchDNS="[https://www.youtube.com,https://s.ytimg.com,https://www.google.com,https://fonts.gstatic.com,https://www.youtube-nocookie.com]"/>
 
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
@@ -10,7 +10,7 @@
     jcr:primaryType="per:PageContent"
     sling:resourceType="themecleanflex/components/page"
     jcr:title="themecleanflex root template"
-    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css?family=Inter:wght@300;400;500;600;700;900&amp;display=swap]"
+    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&amp;display=swap]"
     prefetchDNS="[https://www.youtube.com,https://s.ytimg.com,https://www.google.com,https://fonts.gstatic.com,https://www.youtube-nocookie.com]"/>
 
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -1,5 +1,5 @@
 :root {
-  --font-sans: 'Montserrat', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-size-xs: .75rem;

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/custom.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/custom.css
@@ -1,5 +1,5 @@
 :root {
-  --font-sans: 'Montserrat', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

This PR changes the main sans-serif font-familiy from Montserrat to [Inter](https://fonts.google.com/specimen/Inter). [Inter](https://rsms.me/inter/) includes more [font features](https://rsms.me/inter/#features) which can become useful in the future for accessibility improvements, like [character alternatives](https://rsms.me/inter/#features/cvXX) for small 'l' to differentiate it from a capital 'I'. The font also uses less horizontal space and is open-source. In general, it's closer to standard system fonts like Helvetica and therefore gives the default theme a slightly moderner touch

**Does this close any currently open issues?**

No.

**Any other comments?**

This PR is part of the theme updates I work on. A font-family change might not be of very high priority. I had an excellent experience with using Inter for improving the overall impression of the visual style of applications and websites.

I'm not sure if all features of the font can be enabled when used via Google Fonts. Also, performance wise I didn't see a difference to Montserrat in loading size, but it might be good if a second pair of eyes takes a look at that too.

**Where has this been tested?**

*Browser (version):* Firefox 77.0b3

