### PR TITLE
#79 added listener for pageRendered to close menu when new page rendered

### DIFF
--- a/fragments/header/htmltovue.js
+++ b/fragments/header/htmltovue.js
@@ -13,8 +13,8 @@ module.exports = {
         let mainMenu = $.find('nav>div>div:nth-child(2)')
         f.bindAttribute(mainMenu, 'class', "{'md:hidden': model.collapsed === 'true'}", false)
 
-    	f.replace( $.find('nav>div>div div:nth-child(1)'), '<themecleanflex-components-textlinks v-bind:model="model"></themecleanflex-components-textlinks>')
-        f.replace( $.find('nav>div>div div:nth-child(2)'), '<themecleanflex-components-menubuttons v-bind:model="model"></themecleanflex-components-menubuttons>')
+    	f.replace( $.find('nav>div:first-of-type>div div:nth-child(1)'), '<themecleanflex-components-textlinks v-bind:model="model"></themecleanflex-components-textlinks>')
+        f.replace( $.find('nav>div:first-of-type>div div:nth-child(2)'), '<themecleanflex-components-menubuttons v-bind:model="model"></themecleanflex-components-menubuttons>')
 
         let collapseButton = $.find('nav>div>div:nth-child(3)')
         f.bindEvent( collapseButton, 'click', 'toggleMenu')
@@ -24,8 +24,8 @@ module.exports = {
         f.addStyle( $.find('nav>div:nth-child(2)'), 'height', "menuActive ? menuHeight + 'px' : '0px'")
         f.bindAttribute( $.find('nav>div:nth-child(2)'), 'class', "{'invisible': !menuActive}")
 
-    	f.replace( $.find('nav>div:nth-child(2) div>div:nth-child(1)'), '<themecleanflex-components-textlinks v-bind:model="model"></themecleanflex-components-textlinks>')
-        f.replace( $.find('nav>div:nth-child(2) div>div:nth-child(2)'), '<themecleanflex-components-menubuttons v-bind:model="model"></themecleanflex-components-menubuttons>')
+    	f.replace( $.find('nav>div:last-of-type>div>div:nth-child(1)'), '<themecleanflex-components-textlinks v-bind:model="model"></themecleanflex-components-textlinks>')
+        f.replace( $.find('nav>div:last-of-type>div>div:nth-child(2)'), '<themecleanflex-components-menubuttons v-bind:model="model"></themecleanflex-components-menubuttons>')
 
         f.addElse($);
         $.parent().prepend('<div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>')

--- a/fragments/header/template.vue
+++ b/fragments/header/template.vue
@@ -35,7 +35,7 @@
         props: ['model'],
         data: function() {
           return {
-            menuActive: false,
+            menuActive: true,
             menuHeight: 0
           }
         },
@@ -47,6 +47,9 @@
         },
         mounted: function() {
           this.menuHeight = this.$refs.autoHeight.clientHeight;
+          window.addEventListener('pageRendered', (e) => {
+              this.toggleMenu();
+          }, false);
         },
         computed: {
         	isEditAndEmpty() {

--- a/fragments/header/template.vue
+++ b/fragments/header/template.vue
@@ -35,7 +35,7 @@
         props: ['model'],
         data: function() {
           return {
-            menuActive: true,
+            menuActive: false,
             menuHeight: 0
           }
         },
@@ -48,7 +48,9 @@
         mounted: function() {
           this.menuHeight = this.$refs.autoHeight.clientHeight;
           window.addEventListener('pageRendered', (e) => {
+            if (this.menuActive) {
               this.toggleMenu();
+            }
           }, false);
         },
         computed: {

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/header/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/header/template.vue
@@ -35,7 +35,7 @@
         props: ['model'],
         data: function() {
           return {
-            menuActive: true,
+            menuActive: false,
             menuHeight: 0
           }
         },
@@ -48,7 +48,9 @@
         mounted: function() {
           this.menuHeight = this.$refs.autoHeight.clientHeight;
           window.addEventListener('pageRendered', (e) => {
-              this.toggleMenu();
+              if (this.menuActive) {
+                this.toggleMenu();
+              }
           }, false);
         },
         computed: {

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/header/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/header/template.vue
@@ -35,7 +35,7 @@
         props: ['model'],
         data: function() {
           return {
-            menuActive: false,
+            menuActive: true,
             menuHeight: 0
           }
         },
@@ -47,6 +47,9 @@
         },
         mounted: function() {
           this.menuHeight = this.$refs.autoHeight.clientHeight;
+          window.addEventListener('pageRendered', (e) => {
+              this.toggleMenu();
+          }, false);
         },
         computed: {
         	isEditAndEmpty() {


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

close mobile menu when new page rendered
![image](https://user-images.githubusercontent.com/49845255/83560233-c0031d00-a4ca-11ea-82a7-426745d130e4.png)

**Does this close any currently open issues?**

#79 

**Where has this been tested?**
locally

*Browser (version):* Chrome MacOS
