### PR TITLE
Switch text size with enlarge-text class for horizontal teaser component

### DIFF
--- a/core/src/main/java/com/themecleanflex/models/TeaserhorizontalModel.java
+++ b/core/src/main/java/com/themecleanflex/models/TeaserhorizontalModel.java
@@ -437,6 +437,12 @@ import org.apache.sling.models.annotations.Model;
               "x-form-min": 0,
               "x-form-max": 300,
               "x-form-visible": "model.fullheight != 'true'"
+            },
+            "contentname": {
+              "type": "string",
+              "x-source": "inject",
+              "x-form-label": "Content Name",
+              "x-form-type": "text"
             }
           }
         }
@@ -619,6 +625,10 @@ public class TeaserhorizontalModel extends AbstractComponent {
 	@Inject
 	private String bottompadding;
 
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	@Inject
+	private String contentname;
+
 
 //GEN]
 
@@ -786,6 +796,11 @@ public class TeaserhorizontalModel extends AbstractComponent {
 	/* {"type":"string","x-source":"inject","x-form-label":"Bottom Padding","x-form-type":"materialrange","x-form-min":0,"x-form-max":300,"x-form-visible":"model.fullheight != 'true'"} */
 	public String getBottompadding() {
 		return bottompadding;
+	}
+
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	public String getContentname() {
+		return contentname;
 	}
 
 

--- a/fragments/teaserhorizontal/htmltovue.js
+++ b/fragments/teaserhorizontal/htmltovue.js
@@ -7,6 +7,7 @@ module.exports = {
         let containerClasses = `{
             'md:flex-row-reverse': model.buttonside === 'left',
             'md:flex-row': model.buttonside === 'right',
+            'enlarge-text': model.isprimary === 'true'
         }`
         f.bindAttribute( $, 'class', containerClasses ,false)
 
@@ -14,8 +15,7 @@ module.exports = {
         let textClasses = `{
             'text-left': model.aligncontent === 'left',
             'text-center': model.aligncontent === 'center',
-            'text-right': model.aligncontent === 'right',
-            'text-3xl': model.isprimary === 'true'
+            'text-right': model.aligncontent === 'right'
         }`
         let textDiv = $.find('div').eq(0)
         f.bindAttribute( textDiv, 'class', textClasses,false)

--- a/fragments/teaserhorizontal/template.vue
+++ b/fragments/teaserhorizontal/template.vue
@@ -5,12 +5,12 @@
     v-bind:class="{
             'md:flex-row-reverse': model.buttonside === 'left',
             'md:flex-row': model.buttonside === 'right',
+            'enlarge-text': model.isprimary === 'true'
         }" v-else>
       <div class v-bind:class="{
             'text-left': model.aligncontent === 'left',
             'text-center': model.aligncontent === 'center',
-            'text-right': model.aligncontent === 'right',
-            'text-3xl': model.isprimary === 'true'
+            'text-right': model.aligncontent === 'right'
         }" v-bind:style="`flex-basis:${model.textwidth}%;`">
         <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
         <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
@@ -21,7 +21,7 @@
             'md:justify-end': model.buttonside === 'right',
             'md:justify-start': model.buttonside === 'left',
         }">
-        <a class="btn m-2" v-for="(item,i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
+        <a class="btn m-2" v-for="(item, i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
         v-bind:class="{
             'btn-lg': model.buttonsize === 'large',
             'btn-sm': model.buttonsize === 'small',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/dialog.json
@@ -443,6 +443,13 @@
       "visible": "model.fullheight != 'true'",
       "min": 0,
       "max": 300
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "contentname",
+      "label": "Content Name",
+      "model": "contentname"
     }
   ]
 }

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/template.vue
@@ -5,12 +5,12 @@
     v-bind:class="{
             'md:flex-row-reverse': model.buttonside === 'left',
             'md:flex-row': model.buttonside === 'right',
+            'enlarge-text': model.isprimary === 'true'
         }" v-else>
       <div class v-bind:class="{
             'text-left': model.aligncontent === 'left',
             'text-center': model.aligncontent === 'center',
-            'text-right': model.aligncontent === 'right',
-            'text-3xl': model.isprimary === 'true'
+            'text-right': model.aligncontent === 'right'
         }" v-bind:style="`flex-basis:${model.textwidth}%;`">
         <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
         <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
@@ -21,7 +21,7 @@
             'md:justify-end': model.buttonside === 'right',
             'md:justify-start': model.buttonside === 'left',
         }">
-        <a class="btn m-2" v-for="(item,i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
+        <a class="btn m-2" v-for="(item, i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
         v-bind:class="{
             'btn-lg': model.buttonsize === 'large',
             'btn-sm': model.buttonsize === 'small',


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

Fix an inconsistency between the two teaser components. The vertical teaser
component applied the enlarged text property correctly with the enlarge-text
class, while the horizontal teaser only enlarger the paragraph text. The change
introduces consistency between the components and allows controlling
all text size from CSS.

**Does this close any currently open issues?**

No

**Any other comments?**

During the build, a couple of other files were changed, `dialog.json` and `TeaserhorizontalModel.java`. It's not entirely clear to me why. I assumed it might come from an earlier change in the development branch that might not have been built/compiled. Worth checking during the review.

**Where has this been tested?**

*Browser (version):* Firefox 78.0b3
