### PR TITLE
Change main sans-serif font from Montserrat to Inter

### DIFF
--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/templates/.content.xml
@@ -10,7 +10,7 @@
     jcr:primaryType="per:PageContent"
     sling:resourceType="themecleanflex/components/page"
     jcr:title="themecleanflex root template"
-    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css?family=Montserrat:300%2C300i%2C400%2C400i%2C500%2C500i%2C600%2C600i%2C700%2C700i%2C900%2C900i&amp;amp;display=swap]"
+    siteCSS="[/content/themecleanflex/pages/css/palettes/default.css,/content/themecleanflex/pages/css/palette.css,/content/themecleanflex/pages/css/commons.css,/etc/felibs/themecleanflex.css,/content/themecleanflex/pages/css/custom.css,https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&amp;display=swap]"
     prefetchDNS="[https://www.youtube.com,https://s.ytimg.com,https://www.google.com,https://fonts.gstatic.com,https://www.youtube-nocookie.com]"/>
 
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -1,5 +1,5 @@
 :root {
-  --font-sans: 'Montserrat', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-size-xs: .75rem;

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/custom.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/custom.css
@@ -1,5 +1,5 @@
 :root {
-  --font-sans: 'Montserrat', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 


### PR DESCRIPTION
*Cherry-pick of the font change in #101 which went into the wrong branch. This time sourced and targeted for the develop branch, squashed into one commit.*

Inter includes more font features which can become useful in the future
for accessibility improvements, like character alternatives for small 'l'
to differentiate it from a capital 'I'. The font also uses less horizontal space
and is open-source. In general it's closer to standard system fonts like Helvetica
and therefore gives the default theme a slightly more modern touch

See #101 for details.