### PR TITLE
Only apply standard header style to class-less H-elements

### DIFF
--- a/core/src/main/java/com/themecleanflex/models/AccordionModel.java
+++ b/core/src/main/java/com/themecleanflex/models/AccordionModel.java
@@ -424,6 +424,12 @@ import org.apache.sling.models.annotations.Model;
               "x-form-min": 0,
               "x-form-max": 300,
               "x-form-visible": "model.fullheight != 'true'"
+            },
+            "contentname": {
+              "type": "string",
+              "x-source": "inject",
+              "x-form-label": "Content Name",
+              "x-form-type": "text"
             }
           }
         }
@@ -609,6 +615,10 @@ public class AccordionModel extends AbstractComponent {
 	@Inject
 	private String bottompadding;
 
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	@Inject
+	private String contentname;
+
 
 //GEN]
 
@@ -776,6 +786,11 @@ public class AccordionModel extends AbstractComponent {
 	/* {"type":"string","x-source":"inject","x-form-label":"Bottom Padding","x-form-type":"materialrange","x-form-min":0,"x-form-max":300,"x-form-visible":"model.fullheight != 'true'"} */
 	public String getBottompadding() {
 		return bottompadding;
+	}
+
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	public String getContentname() {
+		return contentname;
 	}
 
 

--- a/fragments/accordion/template.html
+++ b/fragments/accordion/template.html
@@ -11,7 +11,7 @@
 			<div>
 
 				<a class="flex justify-between items-center p-3 cursor-pointer no-underline">
-					<h3 class="text-lg">
+					<h3 class="text-lg m-0">
 						Toggle Title
 					</h3>
 					<svg width="16" height="16" viewBox="0 0 16 16">

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -30,14 +30,14 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div v-for="(item,i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          <div v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
         }">
             <a class="flex justify-between items-center p-3 cursor-pointer no-underline"
             v-on:click="toggleItem(i)">
-              <h3 class="text-lg" v-html="item.title"></h3>
+              <h3 class="text-lg m-0" v-html="item.title"></h3>
               <svg width="16" height="16" viewBox="0 0 16 16" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
                 />

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/dialog.json
@@ -413,6 +413,13 @@
       "visible": "model.fullheight != 'true'",
       "min": 0,
       "max": 300
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "contentname",
+      "label": "Content Name",
+      "model": "contentname"
     }
   ]
 }

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -30,14 +30,14 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div v-for="(item,i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          <div v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
         }">
             <a class="flex justify-between items-center p-3 cursor-pointer no-underline"
             v-on:click="toggleItem(i)">
-              <h3 class="text-lg" v-html="item.title"></h3>
+              <h3 class="text-lg m-0" v-html="item.title"></h3>
               <svg width="16" height="16" viewBox="0 0 16 16" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
                 />

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -827,6 +827,10 @@ video {
   list-style-type: none;
 }
 
+.m-0 {
+  margin: var(--spacing-0);
+}
+
 .m-1 {
   margin: var(--spacing-1);
 }
@@ -1272,7 +1276,7 @@ html {
   font-size: var(--font-size-base);
 }
 
-.enlarge-text h1,
+.enlarge-text h1:not([class]),
 .enlarge-text .text-6xl {
   font-size: var(--font-size-6xl);
   font-weight: 800;
@@ -1281,8 +1285,8 @@ html {
   margin-top: var(--spacing-24);
 }
 
-h1,
-.enlarge-text h2,
+h1:not([class]),
+.enlarge-text h2:not([class]),
 .enlarge-text .text-5xl {
   font-size: var(--font-size-5xl);
   font-weight: 800;
@@ -1291,8 +1295,8 @@ h1,
   margin-top: var(--spacing-20);
 }
 
-h2,
-.enlarge-text h3,
+h2:not([class]),
+.enlarge-text h3:not([class]),
 .enlarge-text .text-4xl {
   font-size: var(--font-size-4xl);
   font-weight: 700;
@@ -1301,8 +1305,8 @@ h2,
   margin-top: var(--spacing-16);
 }
 
-h3,
-.enlarge-text h4,
+h3:not([class]),
+.enlarge-text h4:not([class]),
 .enlarge-text .text-3xl {
   font-size: var(--font-size-3xl);
   font-weight: 700;
@@ -1311,8 +1315,8 @@ h3,
   margin-top: var(--spacing-12);
 }
 
-h4,
-.enlarge-text h5,
+h4:not([class]),
+.enlarge-text h5:not([class]),
 .enlarge-text .text-2xl {
   font-size: var(--font-size-2xl);
   font-weight: 700;
@@ -1321,8 +1325,8 @@ h4,
   margin-top: var(--spacing-10);
 }
 
-h5,
-.enlarge-text h6,
+h5:not([class]),
+.enlarge-text h6:not([class]),
 .enlarge-text .text-xl {
   font-size: var(--font-size-xl);
   font-weight: 700;
@@ -1330,7 +1334,7 @@ h5,
   margin-top: var(--spacing-8);
 }
 
-h6 {
+h6:not([class]) {
   font-size: var(--font-size-lg);
   line-height: var(--line-height-1);
   margin-top: var(--spacing-8);
@@ -1347,26 +1351,26 @@ h6 {
   font-weight: 700;
 }
 
-h1, h2, h3, h4, h5 {
+h1:not([class]), h2:not([class]), h3:not([class]), h4:not([class]), h5:not([class]) {
   margin-top: var(--spacing-6);
   margin-bottom: var(--spacing-6);
 }
 
-h1:first-child,
-h2:first-child,
-h3:first-child,
-h4:first-child,
-h5:first-child,
-h6:first-child {
+h1:not([class]):first-child,
+h2:not([class]):first-child,
+h3:not([class]):first-child,
+h4:not([class]):first-child,
+h5:not([class]):first-child,
+h6:not([class]):first-child {
   margin-top: 0;
 }
 
-h1:last-child,
-h2:last-child,
-h3:last-child,
-h4:last-child,
-h5:last-child,
-h6:last-child {
+h1:not([class]):last-child,
+h2:not([class]):last-child,
+h3:not([class]):last-child,
+h4:not([class]):last-child,
+h5:not([class]):last-child,
+h6:not([class]):last-child {
   margin-bottom: 0;
 }
 

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/styles.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/styles.css
@@ -12,7 +12,7 @@ html {
   @apply font-sans text-base;
 }
 
-.enlarge-text h1,
+.enlarge-text h1:not([class]),
 .enlarge-text .text-6xl {
   @apply text-6xl font-extrabold;
   line-height: var(--line-height-6);
@@ -20,8 +20,8 @@ html {
   margin-top: var(--spacing-24);
 }
 
-h1,
-.enlarge-text h2,
+h1:not([class]),
+.enlarge-text h2:not([class]),
 .enlarge-text .text-5xl {
   @apply text-5xl font-extrabold;
   line-height: var(--line-height-5);
@@ -29,8 +29,8 @@ h1,
   margin-top: var(--spacing-20);
 }
 
-h2,
-.enlarge-text h3,
+h2:not([class]),
+.enlarge-text h3:not([class]),
 .enlarge-text .text-4xl {
   @apply text-4xl font-bold;
   line-height: var(--line-height-4);
@@ -38,8 +38,8 @@ h2,
   margin-top: var(--spacing-16);
 }
 
-h3,
-.enlarge-text h4,
+h3:not([class]),
+.enlarge-text h4:not([class]),
 .enlarge-text .text-3xl {
   @apply text-3xl font-bold;
   line-height: var(--line-height-3);
@@ -47,8 +47,8 @@ h3,
   margin-top: var(--spacing-12);
 }
 
-h4,
-.enlarge-text h5,
+h4:not([class]),
+.enlarge-text h5:not([class]),
 .enlarge-text .text-2xl {
   @apply text-2xl font-bold;
   line-height: var(--line-height-2);
@@ -56,15 +56,15 @@ h4,
   margin-top: var(--spacing-10);
 }
 
-h5,
-.enlarge-text h6,
+h5:not([class]),
+.enlarge-text h6:not([class]),
 .enlarge-text .text-xl {
   @apply text-xl font-bold;
   line-height: var(--line-height-1);
   margin-top: var(--spacing-8);
 }
 
-h6 {
+h6:not([class]) {
   @apply text-lg;
   line-height: var(--line-height-1);
   margin-top: var(--spacing-8);
@@ -81,28 +81,26 @@ h6 {
   @apply font-bold;
 }
 
-h1, h2, h3, h4, h5 {
+h1:not([class]), h2:not([class]), h3:not([class]), h4:not([class]), h5:not([class]) {
   margin-top: var(--spacing-6);
   margin-bottom: var(--spacing-6);
 }
 
-
-
-h1:first-child,
-h2:first-child,
-h3:first-child,
-h4:first-child,
-h5:first-child,
-h6:first-child {
+h1:not([class]):first-child,
+h2:not([class]):first-child,
+h3:not([class]):first-child,
+h4:not([class]):first-child,
+h5:not([class]):first-child,
+h6:not([class]):first-child {
   margin-top: 0;
 }
 
-h1:last-child,
-h2:last-child,
-h3:last-child,
-h4:last-child,
-h5:last-child,
-h6:last-child {
+h1:not([class]):last-child,
+h2:not([class]):last-child,
+h3:not([class]):last-child,
+h4:not([class]):last-child,
+h5:not([class]):last-child,
+h6:not([class]):last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION

<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

Ensure that the default heading styles are not applied when a component
tries to set their heading styles via tailwind classes.

With the changes to typography before, all heading elements where overwritten to have a standard style which broke a couple of components that assumed the default Tailwind behaviour of not applying any styles to the heading elements.

Not the before introduced standard styles for headings are only applied if there is not already a class on the HTML element, assuming when the component author sets classes, he wants to start styling from scratch with the Tailwind utility classes.

This fixes issues with components like the accordion, which uses heading elements for the accordion element title.

**Does this close any currently open issues?**

No.

**Any other comments?**

It seems like the accordion component was not built from html to vue when the content name field was introduced. Thus, this PR features changes to the built files that are not part of the source code change in this PR.

**Where has this been tested?**

*Browser (version):* Firefox 77
