### PR TITLE
Remove the width on the cards container

### DIFF
--- a/fragments/cards/template.html
+++ b/fragments/cards/template.html
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap -mx-3">
+<div class="flex flex-wrap md:-mx-3">
 
   <div class="card my-3 px-0 md:px-3">
     <div class="flex flex-col h-full overflow-hidden">

--- a/fragments/cards/template.html
+++ b/fragments/cards/template.html
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap -mx-3 w-full">
+<div class="flex flex-wrap -mx-3">
 
   <div class="card my-3 px-0 md:px-3">
     <div class="flex flex-col h-full overflow-hidden">

--- a/fragments/cards/template.vue
+++ b/fragments/cards/template.vue
@@ -1,7 +1,7 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
-    <div class="flex flex-wrap -mx-3 w-full"
+    <div class="flex flex-wrap -mx-3"
     v-else>
       <div class="card my-3 px-0 md:px-3" v-bind:class="{
             'lg:w-full': model.cardsperrow == 1,

--- a/fragments/cards/template.vue
+++ b/fragments/cards/template.vue
@@ -1,7 +1,7 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
-    <div class="flex flex-wrap -mx-3"
+    <div class="flex flex-wrap md:-mx-3"
     v-else>
       <div class="card my-3 px-0 md:px-3" v-bind:class="{
             'lg:w-full': model.cardsperrow == 1,

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/cards/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/cards/template.vue
@@ -1,7 +1,7 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
-    <div class="flex flex-wrap -mx-3 w-full"
+    <div class="flex flex-wrap -mx-3"
     v-else>
       <div class="card my-3 px-0 md:px-3" v-bind:class="{
             'lg:w-full': model.cardsperrow == 1,

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/cards/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/cards/template.vue
@@ -1,7 +1,7 @@
 <template>
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
-    <div class="flex flex-wrap -mx-3"
+    <div class="flex flex-wrap md:-mx-3"
     v-else>
       <div class="card my-3 px-0 md:px-3" v-bind:class="{
             'lg:w-full': model.cardsperrow == 1,


### PR DESCRIPTION

<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

Ensure the cards on the same line, vertically left and right, as other
components, like the media component.

![Screenshot from 2020-06-22 11-48-21](https://user-images.githubusercontent.com/105358/85273768-54372300-b47e-11ea-92bc-dcb4b6f086d7.png)

**Does this close any currently open issues?**

Known issue reported by @reusr1, not formally in a ticket.

**Any other comments?**

–

**Where has this been tested?**

*Browser (version):* Firefox 77
