### PR TITLE
Polish teaser margins, fix subtitle style and semantics

### DIFF
--- a/core/src/main/java/com/themecleanflex/models/TeaserverticalModel.java
+++ b/core/src/main/java/com/themecleanflex/models/TeaserverticalModel.java
@@ -528,6 +528,12 @@ import org.apache.sling.models.annotations.Model;
               "x-form-min": 0,
               "x-form-max": 300,
               "x-form-visible": "model.fullheight != 'true'"
+            },
+            "contentname": {
+              "type": "string",
+              "x-source": "inject",
+              "x-form-label": "Content Name",
+              "x-form-type": "text"
             }
           }
         }
@@ -742,6 +748,10 @@ public class TeaserverticalModel extends AbstractComponent {
 	@Inject
 	private String bottompadding;
 
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	@Inject
+	private String contentname;
+
 
 //GEN]
 
@@ -944,6 +954,11 @@ public class TeaserverticalModel extends AbstractComponent {
 	/* {"type":"string","x-source":"inject","x-form-label":"Bottom Padding","x-form-type":"materialrange","x-form-min":0,"x-form-max":300,"x-form-visible":"model.fullheight != 'true'"} */
 	public String getBottompadding() {
 		return bottompadding;
+	}
+
+	/* {"type":"string","x-source":"inject","x-form-label":"Content Name","x-form-type":"text"} */
+	public String getContentname() {
+		return contentname;
 	}
 
 

--- a/fragments/teaserhorizontal/htmltovue.js
+++ b/fragments/teaserhorizontal/htmltovue.js
@@ -19,17 +19,36 @@ module.exports = {
         }`
         let textDiv = $.find('div').eq(0)
         f.bindAttribute( textDiv, 'class', textClasses,false)
-        f.addStyle( textDiv, 'flex-basis', 'model.textwidth', '%')
+        f.addStyle(textDiv, 'flex-basis', 'model.textwidth', '%')
         
-    	f.addIf($.find('h1').first(), "model.showtitle === 'true'")
-        f.addIf($.find('h2').first(), "model.showsubtitle === 'true'")
-        f.addIf($.find('p').first(), "model.showtext === 'true'")
-        f.mapRichField($.find('h1').first(), "model.title")
-        f.mapRichField($.find('h2').first(), "model.subtitle")
-        f.mapRichField($.find('p').first(), "model.text")
+        let title = $.find('h1').first()
+        let titleClasses = `{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }`
+        
+        f.addIf(title, "model.showtitle === 'true'")
+        f.bindAttribute(title, 'class', titleClasses, false)
+        f.mapRichField(title, "model.title")
+
+        let subTitle = $.find('.teaser-subtitle').first()
+        let subTitleClasses = `{
+            'mb-6': model.isprimary === 'true' && model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' && model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' && model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' && model.showtitle === 'true'
+        }`
+        
+        f.addIf(subTitle, "model.showsubtitle === 'true'")
+        f.bindAttribute(subTitle, 'class', subTitleClasses, false)
+        f.mapRichField($.find('.teaser-subtitle').first(), "model.subtitle")
+
+        let teaserText = $.find('.teaser-text').first()
+        f.addIf(teaserText, "model.showtext === 'true'")       
+        f.mapRichField(teaserText, "model.text")
         
         //Buttons
-        let buttonsDiv = $.find('div').eq(1)
+        let buttonsDiv = $.find('.teaser-actions').first();
         let link = buttonsDiv.find('a')
         let buttonsClasses = `{
             'md:justify-end': model.buttonside === 'right',
@@ -47,7 +66,7 @@ module.exports = {
             'btn-white': item.buttoncolor === 'light',
             'btn-black': item.buttoncolor === 'dark'
         }`
-        f.addIf( buttonsDiv, 'model.showbutton == \'true\'')
+        f.addIf( buttonsDiv, "model.showbutton === 'true'")
         f.bindAttribute( buttonsDiv, 'class', buttonsClasses,false)
         f.addFor( link, 'model.buttons')
         f.bindAttribute( link, 'href', f.pathToUrl('item.buttonlink'))

--- a/fragments/teaserhorizontal/template.html
+++ b/fragments/teaserhorizontal/template.html
@@ -1,10 +1,10 @@
 <div class="w-full flex flex-col justify-between items-center">
 	<div class="">
-		<h1>Peregrine blocks</h1>
-		<h2>Et architecto autem tenetur provident ea exercitationem enim.</h2>
-		<p>Eligendi fugit asperiores et. Corrupti voluptatum quasi sit. Adipisci ut voluptatem necessitatibus cumque aspernatur.</p>
+		<h1 class="text-5xl mt-0">Peregrine blocks</h1>
+		<p class="teaser-subtitle text-3xl font-normal">Et architecto autem tenetur provident ea exercitationem enim.</p>
+		<div class="teaser-text"><p>Eligendi fugit asperiores et. Corrupti voluptatum quasi sit. Adipisci ut voluptatem necessitatibus cumque aspernatur.</p></div>
 	</div>
-	<div class="flex flex-wrap justify-center">
+	<div class="teaser-actions flex flex-wrap justify-center">
 		<a href="#" class="btn m-2">Click for more</a>
 	</div>
 </div>

--- a/fragments/teaserhorizontal/template.vue
+++ b/fragments/teaserhorizontal/template.vue
@@ -12,11 +12,22 @@
             'text-center': model.aligncontent === 'center',
             'text-right': model.aligncontent === 'right'
         }" v-bind:style="`flex-basis:${model.textwidth}%;`">
-        <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
-        <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
-        <p v-if="model.showtext === 'true'" v-html="model.text"></p>
+        <h1 class="text-5xl mt-0" v-if="model.showtitle === 'true'"
+        v-bind:class="{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }" v-html="model.title"></h1>
+        <p class="teaser-subtitle text-3xl font-normal" v-if="model.showsubtitle === 'true'"
+        v-bind:class="{
+            'mb-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'true'
+        }" v-html="model.subtitle"></p>
+        <div class="teaser-text" v-if="model.showtext === 'true'"
+        v-html="model.text"></div>
       </div>
-      <div class="flex flex-wrap justify-center" v-if="model.showbutton == 'true'"
+      <div class="teaser-actions flex flex-wrap justify-center" v-if="model.showbutton === 'true'"
       v-bind:class="{
             'md:justify-end': model.buttonside === 'right',
             'md:justify-start': model.buttonside === 'left',

--- a/fragments/teaservertical/htmltovue.js
+++ b/fragments/teaservertical/htmltovue.js
@@ -29,18 +29,36 @@ module.exports = {
 
         let textDiv = $.find('div>div>div').first()
         f.bindAttribute( textDiv, 'class', textClasses, false)
-        f.addStyle( textDiv, 'width', 'model.textwidth', '%')
+        f.addStyle(textDiv, 'width', 'model.textwidth', '%')
+        
+        let title = $.find('h1').first()
+        let titleClasses = `{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }`
 
-        f.addIf($.find('h1').first(), "model.showtitle === 'true'")
-        f.addIf($.find('h2').first(), "model.showsubtitle === 'true'")
+        f.addIf(title, "model.showtitle === 'true'")
+        f.bindAttribute(title, 'class', titleClasses, false)
+        f.mapRichField(title, "model.title")
 
-        f.addIf($.find('p').first(), "model.showtext === 'true'")
-        f.mapRichField($.find('h1').first(), "model.title")
-        f.mapRichField($.find('h2').first(), "model.subtitle")
-        f.mapRichField($.find('p').first(), "model.text")
+        let subTitle = $.find('.teaser-subtitle').first()
+        let subTitleClasses = `{
+            'mb-6': model.isprimary === 'true' && model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' && model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' && model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' && model.showtitle === 'true'
+        }`
+        
+        f.addIf(subTitle, "model.showsubtitle === 'true'")
+        f.bindAttribute(subTitle, 'class', subTitleClasses, false)
+        f.mapRichField(subTitle, "model.subtitle")
+
+        let teaserText = $.find('.teaser-text').first()
+        f.addIf(teaserText, "model.showtext === 'true'")       
+        f.mapRichField(teaserText, "model.text")
 
         //Buttons
-        let buttonsDiv = $.find('.flex-wrap').first()
+        let buttonsDiv = $.find('.teaser-actions').first()
         let link = buttonsDiv.find('a').first()
         let buttonsClasses = `{
             'justify-start': model.alignbuttons === 'start',
@@ -66,7 +84,7 @@ module.exports = {
         f.addStyle( link, 'backgroundColor', 'item.buttoncolor')
         f.addStyle( link, 'borderColor', 'item.buttoncolor')
 
-        f.addIf( buttonsDiv, 'model.showbutton == \'true\'')
+        f.addIf( buttonsDiv, "model.showbutton == 'true'")
         f.bindAttribute( buttonsDiv, 'class', buttonsClasses, false)
 
         f.addElse($)

--- a/fragments/teaservertical/template.html
+++ b/fragments/teaservertical/template.html
@@ -4,11 +4,11 @@
   </div>
 	<div class="flex flex-col flex-grow mb-3 md:px-3">
 		<div class="">
-			<h1>Peregrine blocks</h1>
-			<h2>Et architecto autem tenetur provident ea exercitationem enim.</h2>
-			<p>Eligendi fugit asperiores et. Corrupti voluptatum quasi sit. Adipisci ut voluptatem necessitatibus cumque aspernatur.</p>
+			<h1 class="text-5xl mt-0">Peregrine blocks</h1>
+			<p class="teaser-subtitle text-3xl font-normal">Et architecto autem tenetur provident ea exercitationem enim.</p>
+			<div class="teaser-text"><p>Eligendi fugit asperiores et. Corrupti voluptatum quasi sit. Adipisci ut voluptatem necessitatibus cumque aspernatur.</p></div>
 		</div>
-		<div class="flex flex-wrap p-0 -mx-2">
+		<div class="teaser-actions flex flex-wrap p-0 -mx-2">
 			<a href="#" class="btn m-2">Click for more</a>
 		</div>
 	</div>

--- a/fragments/teaservertical/template.vue
+++ b/fragments/teaservertical/template.vue
@@ -20,17 +20,28 @@
             'self-center': model.aligncontent === 'center',
             'self-end': model.aligncontent === 'right'
         }" v-bind:style="`width:${model.textwidth}%;`">
-          <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
-          <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
-          <p v-if="model.showtext === 'true'" v-html="model.text"></p>
+          <h1 class="text-5xl mt-0" v-if="model.showtitle === 'true'"
+          v-bind:class="{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }" v-html="model.title"></h1>
+          <p class="teaser-subtitle text-3xl font-normal" v-if="model.showsubtitle === 'true'"
+          v-bind:class="{
+            'mb-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'true'
+        }" v-html="model.subtitle"></p>
+          <div class="teaser-text" v-if="model.showtext === 'true'"
+          v-html="model.text"></div>
         </div>
-        <div class="flex flex-wrap p-0 -mx-2" v-if="model.showbutton == 'true'"
+        <div class="teaser-actions flex flex-wrap p-0 -mx-2" v-if="model.showbutton == 'true'"
         v-bind:class="{
             'justify-start': model.alignbuttons === 'start',
             'justify-center': model.alignbuttons === 'center',
             'justify-end': model.alignbuttons === 'end'
         }">
-          <a class="btn m-2" v-for="(item,i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
+          <a class="btn m-2" v-for="(item, i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
           v-bind:class="{
             'btn-lg': model.buttonsize === 'large',
             'btn-sm': model.buttonsize === 'small',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaserhorizontal/template.vue
@@ -12,11 +12,22 @@
             'text-center': model.aligncontent === 'center',
             'text-right': model.aligncontent === 'right'
         }" v-bind:style="`flex-basis:${model.textwidth}%;`">
-        <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
-        <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
-        <p v-if="model.showtext === 'true'" v-html="model.text"></p>
+        <h1 class="text-5xl mt-0" v-if="model.showtitle === 'true'"
+        v-bind:class="{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }" v-html="model.title"></h1>
+        <p class="teaser-subtitle text-3xl font-normal" v-if="model.showsubtitle === 'true'"
+        v-bind:class="{
+            'mb-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'true'
+        }" v-html="model.subtitle"></p>
+        <div class="teaser-text" v-if="model.showtext === 'true'"
+        v-html="model.text"></div>
       </div>
-      <div class="flex flex-wrap justify-center" v-if="model.showbutton == 'true'"
+      <div class="teaser-actions flex flex-wrap justify-center" v-if="model.showbutton === 'true'"
       v-bind:class="{
             'md:justify-end': model.buttonside === 'right',
             'md:justify-start': model.buttonside === 'left',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaservertical/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaservertical/dialog.json
@@ -527,6 +527,13 @@
       "visible": "model.fullheight != 'true'",
       "min": 0,
       "max": 300
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "contentname",
+      "label": "Content Name",
+      "model": "contentname"
     }
   ]
 }

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaservertical/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/teaservertical/template.vue
@@ -20,17 +20,28 @@
             'self-center': model.aligncontent === 'center',
             'self-end': model.aligncontent === 'right'
         }" v-bind:style="`width:${model.textwidth}%;`">
-          <h1 v-if="model.showtitle === 'true'" v-html="model.title"></h1>
-          <h2 v-if="model.showsubtitle === 'true'" v-html="model.subtitle"></h2>
-          <p v-if="model.showtext === 'true'" v-html="model.text"></p>
+          <h1 class="text-5xl mt-0" v-if="model.showtitle === 'true'"
+          v-bind:class="{
+            'mb-6': model.isprimary === 'true',
+            'mb-3': model.isprimary !== 'true'
+        }" v-html="model.title"></h1>
+          <p class="teaser-subtitle text-3xl font-normal" v-if="model.showsubtitle === 'true'"
+          v-bind:class="{
+            'mb-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'false',
+            'my-6': model.isprimary === 'true' &amp;&amp; model.showtitle === 'true',
+            'mb-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'false',
+            'my-3': model.isprimary !== 'true' &amp;&amp; model.showtitle === 'true'
+        }" v-html="model.subtitle"></p>
+          <div class="teaser-text" v-if="model.showtext === 'true'"
+          v-html="model.text"></div>
         </div>
-        <div class="flex flex-wrap p-0 -mx-2" v-if="model.showbutton == 'true'"
+        <div class="teaser-actions flex flex-wrap p-0 -mx-2" v-if="model.showbutton == 'true'"
         v-bind:class="{
             'justify-start': model.alignbuttons === 'start',
             'justify-center': model.alignbuttons === 'center',
             'justify-end': model.alignbuttons === 'end'
         }">
-          <a class="btn m-2" v-for="(item,i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
+          <a class="btn m-2" v-for="(item, i) in model.buttons" :key="i" v-bind:href="$helper.pathToUrl(item.buttonlink)"
           v-bind:class="{
             'btn-lg': model.buttonsize === 'large',
             'btn-sm': model.buttonsize === 'small',

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -787,6 +787,10 @@ video {
   flex-grow: 1;
 }
 
+.font-normal {
+  font-weight: 400;
+}
+
 .font-medium {
   font-weight: 500;
 }
@@ -821,6 +825,10 @@ video {
 
 .text-4xl {
   font-size: var(--font-size-4xl);
+}
+
+.text-5xl {
+  font-size: var(--font-size-5xl);
 }
 
 .list-none {
@@ -863,6 +871,11 @@ video {
   margin-right: var(--spacing-3);
 }
 
+.my-6 {
+  margin-top: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
+}
+
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
@@ -876,6 +889,10 @@ video {
 .-mx-3 {
   margin-left: calc(var(--spacing-3) * -1);
   margin-right: calc(var(--spacing-3) * -1);
+}
+
+.mt-0 {
+  margin-top: var(--spacing-0);
 }
 
 .mb-1 {
@@ -900,6 +917,10 @@ video {
 
 .mr-4 {
   margin-right: var(--spacing-4);
+}
+
+.mb-6 {
+  margin-bottom: var(--spacing-6);
 }
 
 .max-w-3xl {
@@ -1281,11 +1302,17 @@ html {
 }
 
 .enlarge-text h1:not([class]),
+.enlarge-text .text-5xl,
 .text-6xl {
   font-size: var(--font-size-6xl);
   font-weight: 800;
   line-height: var(--line-height-6);
   letter-spacing: -0.02em;
+}
+
+.enlarge-text h1:not([class]),
+.enlarge-text .text-5xl:not([class*=my-]):not([class*=mt-]),
+.text-6xl {
   margin-top: var(--spacing-24);
 }
 
@@ -1365,7 +1392,7 @@ h6:not([class]) {
   margin-bottom: 0;
 }
 
-.enlarge-text p,
+.enlarge-text p:not([class*=text-]),
 .enlarge-text .text-lg {
   font-size: var(--font-size-xl);
   line-height: var(--line-height-2);
@@ -1396,6 +1423,15 @@ h4:not([class]):last-child,
 h5:not([class]):last-child,
 h6:not([class]):last-child {
   margin-bottom: 0;
+}
+
+.text-xl.font-normal,
+.text-2xl.font-normal,
+.text-3xl.font-normal,
+.text-4xl.font-normal,
+.text-5xl.font-normal,
+.text-6xl.font-normal {
+  font-weight: 400;
 }
 
 a {

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/styles.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/styles.css
@@ -13,10 +13,16 @@ html {
 }
 
 .enlarge-text h1:not([class]),
+.enlarge-text .text-5xl,
 .text-6xl {
   @apply text-6xl font-extrabold;
   line-height: var(--line-height-6);
   letter-spacing: -0.02em;
+}
+
+.enlarge-text h1:not([class]),
+.enlarge-text .text-5xl:not([class*=my-]):not([class*=mt-]),
+.text-6xl {
   margin-top: var(--spacing-24);
 }
 
@@ -53,6 +59,8 @@ h3:not([class]),
   line-height: var(--line-height-3);
   letter-spacing: -0.02em;
 }
+
+
 
 h3:not([class]),
 .enlarge-text h4:not([class]) {
@@ -91,7 +99,7 @@ h6:not([class]) {
   margin-bottom: 0;
 }
 
-.enlarge-text p,
+.enlarge-text p:not([class*=text-]),
 .enlarge-text .text-lg {
   @apply text-xl;
   line-height: var(--line-height-2);
@@ -122,6 +130,15 @@ h4:not([class]):last-child,
 h5:not([class]):last-child,
 h6:not([class]):last-child {
   margin-bottom: 0;
+}
+
+.text-xl.font-normal,
+.text-2xl.font-normal,
+.text-3xl.font-normal,
+.text-4xl.font-normal,
+.text-5xl.font-normal,
+.text-6xl.font-normal {
+  font-weight: 400;
 }
 
 a {


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

Add exceptional margin handling for teasers on normal and enlarged
text mode to make the visual style more sound in this context. Change
the subtitle element from h2 to a p-tag to make semantics accessible
meaningful.

**Does this close any currently open issues?**

–

**Any other comments?**

–

**Where has this been tested?**

*Browser (version):* Firefox 77
