### PR TITLE
Fix accordion semantics, update style

### DIFF
--- a/fragments/accordion/htmltovue.js
+++ b/fragments/accordion/htmltovue.js
@@ -46,14 +46,15 @@ module.exports = {
 
         let accordionContainerClasses = `{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' && model.cardborder === 'true',
-            'border-b border-solid border-gray-900': model.colorscheme === 'dark' && model.cardborder === 'true'
+            'border-b border-solid border-gray-900': model.colorscheme === 'dark' && model.cardborder === 'true',
+            'bg-secondary': active[i]
         }`
 
         //Accordion Container
         let accordionContainer = $.find('div:nth-child(1)').eq(1)
         f.addFor(accordionContainer, 'model.accordiontoggle')
         f.bindAttribute( accordionContainer, 'id', "`accordion${_uid}${parseInt(i)+1}`")
-        f.bindAttribute( accordionContainer, 'class', accordionContainerClasses, false)
+        f.bindAttribute(accordionContainer, 'class', accordionContainerClasses, false)
 
         //Accordion Item Title Bar
         let toggle = $.find('.accordion-toggle-button').first()

--- a/fragments/accordion/htmltovue.js
+++ b/fragments/accordion/htmltovue.js
@@ -56,9 +56,11 @@ module.exports = {
         f.bindAttribute( accordionContainer, 'class', accordionContainerClasses, false)
 
         //Accordion Item Title Bar
-        let a = $.find('a').first()
-        f.bindEvent( a, 'click', "toggleItem(i)")
-        f.mapRichField( a.find('h3'), "item.title")
+        let toggle = $.find('.accordion-toggle-button').first()
+        let toggleText = toggle.find('span');
+        f.bindEvent(toggle, 'click', "toggleItem(i)")
+        f.bindAttribute(toggle, 'aria-expanded', "active[i] ? 'true' : 'false'")
+        f.mapRichField(toggleText, "item.title")
 
         //Acocordion Item Body
         f.mapRichField($.find('div.card-content > div').first(), "item.text")

--- a/fragments/accordion/template.html
+++ b/fragments/accordion/template.html
@@ -8,16 +8,16 @@
 		</div>
 
 		<div class="accordion-container px-0 sm:mx-3 flex-grow overflow-hidden">
-			<div>
+			<div class="border-b">
 
-				<a class="flex justify-between items-center p-3 cursor-pointer no-underline">
-					<h3 class="text-lg m-0">
-						Toggle Title
-					</h3>
-					<svg width="16" height="16" viewBox="0 0 16 16">
-						<path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"/>
-					</svg>
-				</a>
+				<h3 class="accordion-item-header">
+					<button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full">
+						<span>Toggle Title</span>
+						<svg width="16" height="16" viewBox="0 0 16 16" focusable="false">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"/>
+						</svg>
+					</button>
+				</h3>
 
 				<div class="card-content overflow-hidden transition-height" role="tabpanel">
 					<div class="p-3">

--- a/fragments/accordion/template.html
+++ b/fragments/accordion/template.html
@@ -8,12 +8,12 @@
 		</div>
 
 		<div class="accordion-container px-0 sm:mx-3 flex-grow overflow-hidden">
-			<div class="border-b">
+			<div class="accordion-item border-b transition-colors duration-200 ease-in-out">
 
 				<h3 class="accordion-item-header">
 					<button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full">
 						<span>Toggle Title</span>
-						<svg width="16" height="16" viewBox="0 0 16 16" focusable="false">
+						<svg width="16" height="16" viewBox="0 0 16 16" focusable="false" class="transition-transform duration-150 ease-in-out">
 							<path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"/>
 						</svg>
 					</button>

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -30,17 +30,19 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div class="border-b" v-for="(item, i) in model.accordiontoggle" :key="i"
-          v-bind:id="`accordion${_uid}${parseInt(i)+1}`" v-bind:class="{
+          <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
+          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
-            'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
+            'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',
+            'bg-secondary': active[i]
         }">
             <h3 class="accordion-item-header">
               <button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full"
               v-on:click="toggleItem(i)" v-bind:aria-expanded="active[i] ? 'true' : 'false'">
                 <span v-html="item.title"></span>
                 <svg width="16" height="16" viewBox="0 0 16 16" focusable="false"
-                v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
+                class="transition-transform duration-150 ease-in-out" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
                   />
                 </svg>

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -30,19 +30,22 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
-          v-bind:class="{
+          <div class="border-b" v-for="(item, i) in model.accordiontoggle" :key="i"
+          v-bind:id="`accordion${_uid}${parseInt(i)+1}`" v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
         }">
-            <a class="flex justify-between items-center p-3 cursor-pointer no-underline"
-            v-on:click="toggleItem(i)">
-              <h3 class="text-lg m-0" v-html="item.title"></h3>
-              <svg width="16" height="16" viewBox="0 0 16 16" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
-                />
-              </svg>
-            </a>
+            <h3 class="accordion-item-header">
+              <button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full"
+              v-on:click="toggleItem(i)" v-bind:aria-expanded="active[i] ? 'true' : 'false'">
+                <span v-html="item.title"></span>
+                <svg width="16" height="16" viewBox="0 0 16 16" focusable="false"
+                v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
+                  />
+                </svg>
+              </button>
+            </h3>
             <div class="card-content overflow-hidden transition-height" role="tabpanel"
             v-bind:style="`height:${active[i] ? heights[i] + 'px' : '0px'};`">
               <div class="p-3" v-html="item.text" v-bind:ref="`cardContent${i}`"></div>

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -30,17 +30,19 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div class="border-b" v-for="(item, i) in model.accordiontoggle" :key="i"
-          v-bind:id="`accordion${_uid}${parseInt(i)+1}`" v-bind:class="{
+          <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
+          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
-            'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
+            'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',
+            'bg-secondary': active[i]
         }">
             <h3 class="accordion-item-header">
               <button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full"
               v-on:click="toggleItem(i)" v-bind:aria-expanded="active[i] ? 'true' : 'false'">
                 <span v-html="item.title"></span>
                 <svg width="16" height="16" viewBox="0 0 16 16" focusable="false"
-                v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
+                class="transition-transform duration-150 ease-in-out" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
                   />
                 </svg>

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -30,19 +30,22 @@
             'rounded-lg': model.roundedcorners == 'large',
             'rounded-full': model.roundedcorners == 'full'
         }">
-          <div v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
-          v-bind:class="{
+          <div class="border-b" v-for="(item, i) in model.accordiontoggle" :key="i"
+          v-bind:id="`accordion${_uid}${parseInt(i)+1}`" v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true'
         }">
-            <a class="flex justify-between items-center p-3 cursor-pointer no-underline"
-            v-on:click="toggleItem(i)">
-              <h3 class="text-lg m-0" v-html="item.title"></h3>
-              <svg width="16" height="16" viewBox="0 0 16 16" v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
-                />
-              </svg>
-            </a>
+            <h3 class="accordion-item-header">
+              <button type="button" class="accordion-toggle-button font-bold m-0 flex justify-between items-center p-3 cursor-pointer w-full"
+              v-on:click="toggleItem(i)" v-bind:aria-expanded="active[i] ? 'true' : 'false'">
+                <span v-html="item.title"></span>
+                <svg width="16" height="16" viewBox="0 0 16 16" focusable="false"
+                v-bind:style="`transform:${active[i] ? 'rotate(180deg)': 'rotate(0)'};`">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.293 4.29291L14.7072 5.70712L8.00008 12.4142L1.29297 5.70712L2.70718 4.29291L8.00008 9.5858L13.293 4.29291Z"
+                  />
+                </svg>
+              </button>
+            </h3>
             <div class="card-content overflow-hidden transition-height" role="tabpanel"
             v-bind:style="`height:${active[i] ? heights[i] + 'px' : '0px'};`">
               <div class="p-3" v-html="item.text" v-bind:ref="`cardContent${i}`"></div>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
@@ -104,7 +104,7 @@
 
 #peregrine-app .theme-light .accordion-container,
 #peregrine-app .theme-dark .accordion-container {
-  background-color: var(--bg-secondary-color);
+  background-color: var(--bg-primary-color);
 }
 
 #peregrine-app .accordion-toggle-button {

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
@@ -105,15 +105,21 @@
 #peregrine-app .theme-light .accordion-container,
 #peregrine-app .theme-dark .accordion-container {
   background-color: var(--bg-secondary-color);
-  border-width: 1px;
-  border-style: solid;
 }
 
-#peregrine-app .theme-light .accordion-container > div,
-#peregrine-app .theme-dark .accordion-container > div {
-  background-color: var(--bg-secondary-color) !important;
-  border-bottom-width: 1px;
-  border-style: solid;
+#peregrine-app .accordion-toggle-button {
+  font-family: inherit;
+  -webkit-appearance: none;
+  border: 0;
+  background-color: none;
+}
+
+#peregrine-app .accordion-toggle-button:focus {
+  outline: 0;
+}
+
+#peregrine-app .accordion-toggle-button:focus svg {
+  fill: var(--btn-focus-border-color, blue);
 }
 
 #peregrine-app svg:not(.fill-current) {

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -617,6 +617,10 @@ video {
   background-color: var(--color-blue-700);
 }
 
+.bg-secondary {
+  background-color: var(--bg-secondary-color);
+}
+
 .hover\:bg-black:hover {
   --bg-opacity: 1;
   background-color: #000;
@@ -1276,8 +1280,28 @@ video {
   z-index: 10;
 }
 
+.transition-colors {
+  transition-property: background-color, border-color, color, fill, stroke;
+}
+
 .transition-opacity {
   transition-property: opacity;
+}
+
+.transition-transform {
+  transition-property: transform;
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.duration-150 {
+  transition-duration: 150ms;
+}
+
+.duration-200 {
+  transition-duration: 200ms;
 }
 
 .aspect-ratio-16\/9 {

--- a/ui.apps/tailwind.config.js
+++ b/ui.apps/tailwind.config.js
@@ -153,7 +153,11 @@ module.exports = {
       '56': 'var(--spacing-56)',
       '64': 'var(--spacing-64)',
     },
-    backgroundColor: theme => theme('colors'),
+    backgroundColor: theme => ({
+      ...theme('colors'),
+      primary: 'var(--bg-primary-color)',
+      secondary: 'var(--bg-secondary-color)'
+    }),
     backgroundPosition: {
       bottom: 'bottom',
       center: 'center',


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

* Enhance accessibility of accordion component visually and for screen readers. basically, replaces the previously with an a-tag implemented toggle with a HTML button and aria-expanded, which according to my research of all solutions, is the better one. It's also the solution coming from Heydon Pickering's Inclusive Component book.
* Make accordion more sound within its theming options.

![Screen Shot 2020-06-26 at 16 43 20](https://user-images.githubusercontent.com/105358/85869981-bf5d5e00-b7cc-11ea-83ab-1424972534de.png)
*Default state without border, dark variant*

![Screen Shot 2020-06-26 at 16 43 27](https://user-images.githubusercontent.com/105358/85869978-bec4c780-b7cc-11ea-99e4-4cfea324ac5a.png)
*Item expanded. Transition to secondary background colour, including transition of expanded/collapsed indicator*

**Does this close any currently open issues?**

–

**Any other comments?**

–

**Where has this been tested?**

*Browser (version):* Firefox 77
