### PR TITLE
Added support for base analytics integration

### DIFF
--- a/ui.apps/package-lock.json
+++ b/ui.apps/package-lock.json
@@ -4,6 +4,45 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@analytics/cookie-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@analytics/cookie-utils/-/cookie-utils-0.2.3.tgz",
+      "integrity": "sha512-RiMAVpSluRbWb2hlT9wMJ0r2l+MUZzScYjY+w2iWRzjOr9Zzzs4tYzJT6Sd94PDz3LzCuf4aGOwS6pkKXTEBLw==",
+      "dev": true
+    },
+    "@analytics/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@analytics/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-niKC+NRCdVnrTW/cQqfMOrxZSIzQBQ0aavRIUwgdNAiSYXbtlGvsM24ylAKC+EwXMkwf9c4n3QbxxHtNpnvszw==",
+      "dev": true,
+      "requires": {
+        "analytics-utils": "^0.2.2"
+      }
+    },
+    "@analytics/google-analytics": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@analytics/google-analytics/-/google-analytics-0.4.0.tgz",
+      "integrity": "sha512-IuXKIdThT/AqUxeOY3Oe8TCFd6JsAzdXUHtnzCGwQyCH1SzEQwjvSqBnBrGdZdg+FbstNAgpeBIRdffa6vQRUQ==",
+      "dev": true,
+      "requires": {
+        "universal-analytics": "^0.4.20"
+      }
+    },
+    "@analytics/perfumejs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@analytics/perfumejs/-/perfumejs-0.2.0.tgz",
+      "integrity": "sha512-youixRV59Set4W6YshBZ1m3gLLMtqJzyJrNBPIddH1Rb+4A0+ExV316bhfjfO+rAn4dt/KkPlvBDrFlYh2YIng==",
+      "dev": true
+    },
+    "@analytics/storage-utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@analytics/storage-utils/-/storage-utils-0.2.4.tgz",
+      "integrity": "sha512-VHRggJbRY8vHIADWVwbq9cZux0L9LdmlN31XA3daVAI4gMkKdQEocxB7KqGDt6SfIJ3NYi/qh1nRJGooYmTBiA==",
+      "dev": true,
+      "requires": {
+        "@analytics/cookie-utils": "^0.2.3"
+      }
+    },
     "@fullhuman/postcss-purgecss": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-1.1.0.tgz",
@@ -171,6 +210,26 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "analytics": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-yrM/XClBqddN50GYytbdnD/UagHFujx4U4TNw7KRpj1r4wUE4aiz1usKdKg6GKJDr3ojSgoRRQONQiOjS3sEDw==",
+      "dev": true,
+      "requires": {
+        "@analytics/core": "^0.6.0",
+        "@analytics/storage-utils": "^0.2.4"
+      }
+    },
+    "analytics-utils": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/analytics-utils/-/analytics-utils-0.2.2.tgz",
+      "integrity": "sha512-fdbc+MeoNrkwCAbGD/qgedyvRbPnImmWiInAgZ51KpINmKITpdtWV+6riHVA1YBSrb8IyYlfxn98IeWyN9a0+Q==",
+      "dev": true,
+      "requires": {
+        "@analytics/storage-utils": "^0.2.4",
+        "dlv": "^1.1.3"
       }
     },
     "ansi-regex": {
@@ -1944,6 +2003,12 @@
       "requires": {
         "path-type": "^3.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.1",
@@ -4274,6 +4339,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "perfume.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/perfume.js/-/perfume.js-5.1.0.tgz",
+      "integrity": "sha512-ICZ54+V/6v7Qa40oQw7JtA0wcczYJb3azx+g8FP5u1ZawIEjnzAIVeBBkclkfqN1y25p9qjKjhJqvdzk9kugQg==",
+      "dev": true
+    },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
@@ -6231,6 +6302,72 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "universal-analytics": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.23.tgz",
+      "integrity": "sha512-lgMIH7XBI6OgYn1woDEmxhGdj8yDefMKg7GkWdeATAlQZFrMrNyxSkpDzY57iY0/6fdlzTbBV03OawvvzG+q7A==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "request": "^2.88.2",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
     },
     "universalify": {
       "version": "0.1.2",

--- a/ui.apps/package.json
+++ b/ui.apps/package.json
@@ -39,7 +39,11 @@
     "vue-template-compiler": "^2.5.22"
   },
   "devDependencies": {
+    "@analytics/google-analytics": "^0.4.0",
+    "@analytics/perfumejs": "^0.2.0",
     "@fullhuman/postcss-purgecss": "^1.1.0",
+    "analytics": "^0.5.3",
+    "perfume.js": "^5.1.0",
     "pixelmatch": "^5.0.2",
     "pngjs": "^3.4.0",
     "postcss": "^7.0.14",

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -156,6 +156,53 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${resource.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes/etc/felibs/themecleanflex/dependencies</outputDirectory>
+                            <resources>          
+                                <resource>
+                                    <directory>${basedir}/node_modules/analytics/dist</directory>
+                                    <includes>
+                                        <include>analytics.min.js</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>${basedir}/node_modules/@analytics/perfumejs/dist/@analytics</directory>
+                                    <includes>
+                                        <include>perfumejs.min.js</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>${basedir}/node_modules/@analytics/google-analytics/dist/@analytics</directory>
+                                    <includes>
+                                        <include>google-analytics.min.js</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>${basedir}/node_modules/perfume.js/dist</directory>
+                                    <includes>
+                                        <include>perfume.umd.min.js</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>              
+                        </configuration>            
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/js/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/js/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:primaryType="per:Page" jcr:title="JavaScript files" jcr:description="JavaScript files">
+    <jcr:content jcr:primaryType="per:PageContent" sling:resourceType="themecleanflex/components/page" jcr:title="js" template="/content/themecleanflex/templates" excludeFromSitemap="{Boolean}true">
+    </jcr:content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/js/site-analytics.js
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/js/site-analytics.js
@@ -1,0 +1,16 @@
+var Analytics = _analytics.init({
+    app: 'YOUR-SITE',
+    plugins: [
+        {
+          name: 'console-plugin',
+          track: ({ payload}) => { console.log(payload) }
+        },
+        analyticsPerfumeJs({
+            perfume: Perfume,
+            category: 'perfMetrics'
+        }),
+        analyticsGa.init({
+           trackingId: 'YOUR-GOOGLE-TRACKING-ID'    
+        })
+    ]
+ })


### PR DESCRIPTION
Perform the following to verify this change:

1. Deploy themeclean-flex.

```
$ percli comple -d
```

2. Create a new site.

3. Add the following files to "Root Template" > "Site JS Files":

* /etc/felibs/themecleanflex/dependencies/analytics.min.js
* /etc/felibs/themecleanflex/dependencies/google-analytics.min.js
* /etc/felibs/themecleanflex/dependencies/perfume.umd.min.js
* /etc/felibs/themecleanflex/dependencies/perfumejs.min.js

4. Modify `/content/YOURSITE/pages/js/site-analytics.js` to meet your needs. At a minimum, change `YOUR-GOOGLE-TRACKING-ID` and `YOUR-SITE`. When you load a page, you should see performance metrics in the console and sent to Google Analytics.