### PR TITLE
Issues/135

### DIFF
--- a/fragments/navigation/model.json
+++ b/fragments/navigation/model.json
@@ -11,6 +11,13 @@
           "x-form-label": "Root Page",
           "x-form-browserRoot": "/content/themecleanflex/pages"
         },
+        "excludesitemapexcludes": {
+          "type": "string",
+          "x-source": "inject",
+          "x-form-label": "Exclude pages Excluded in Sitemap",
+          "x-form-type": "materialswitch",
+          "x-form-default": false
+        },
         "justifyitems": {
           "type": "string",
           "x-source": "inject",

--- a/fragments/navigation/template.vue
+++ b/fragments/navigation/template.vue
@@ -45,11 +45,11 @@
 </script>
 
 <style>
-  .dropdown-list {
+  .flex.dropdown-list {
     display: none;
     position: fixed;
   }
-  .dropdown-container:hover .dropdown-list, .dropdown-container:focus-within .dropdown-list {
+  .flex.dropdown-container:hover .flex.dropdown-list, .flex.dropdown-container:focus-within .flex.dropdown-list {
     display: flex;
   }
   

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/dialog.json
@@ -8,6 +8,16 @@
       "model": "rootpage"
     },
     {
+      "type": "materialswitch",
+      "textOn": "yes",
+      "textOff": "no",
+      "valueOn": "true",
+      "valueOff": "false",
+      "placeholder": "excludesitemapexcludes",
+      "label": "Exclude pages Excluded in Sitemap",
+      "model": "excludesitemapexcludes"
+    },
+    {
       "type": "material-radios",
       "values": [
         {

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
@@ -45,11 +45,11 @@
 </script>
 
 <style>
-  .dropdown-list {
+  .flex.dropdown-list {
     display: none;
     position: fixed;
   }
-  .dropdown-container:hover .dropdown-list, .dropdown-container:focus-within .dropdown-list {
+  .flex.dropdown-container:hover .flex.dropdown-list, .flex.dropdown-container:focus-within .flex.dropdown-list {
     display: flex;
   }
   


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**
This adds an Exclude Sitemap option to the multilevel navigation component so that it will hide pages that are excluded from the sitemap. It also fixes the CSS hover issues so that the drop-down navigation shows correctly. Thanks to @smcgrath0 for the CSS fixes.

**Does this close any currently open issues?**
It will resolve #135

**Where has this been tested?**
Tested on Chrome and Safari, css and backend issues are both working.