### PR TITLE
#144 fixed multinavigation comp dark themes

### DIFF
--- a/fragments/navigation/hatch.js
+++ b/fragments/navigation/hatch.js
@@ -18,7 +18,6 @@ module.exports = {
         f.mapField(rootLink, 'child.title', "model.childrenPages", "title");
         f.bindAttribute(rootLink, 'href', "child.childrenPages.length > 0 ? false : child.path +'.html'");
         f.bindAttribute(rootLink, 'class', "model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'",false);
-        f.bindAttribute(rootLink, "data-per-inline", "`model.childrenPages.${i}.title`")
         
         let nested = $.find('div').eq(1);
         f.addIf(nested, 'child.hasChildren && child.childrenPages && child.childrenPages.length > 0')

--- a/fragments/navigation/hatch.js
+++ b/fragments/navigation/hatch.js
@@ -18,11 +18,10 @@ module.exports = {
         f.mapField(rootLink, 'child.title', "model.childrenPages", "title");
         f.bindAttribute(rootLink, 'href', "child.childrenPages.length > 0 ? false : child.path +'.html'");
         f.bindAttribute(rootLink, 'class', "model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'",false);
+        f.bindAttribute(rootLink, "data-per-inline", "`model.childrenPages.${i}.title`")
         
         let nested = $.find('div').eq(1);
         f.addIf(nested, 'child.hasChildren && child.childrenPages && child.childrenPages.length > 0')
-
-        f.bindAttribute($.find('div').eq(2), 'class', "model.colorscheme === 'dark' ? 'theme-dark': 'theme-light'", false)
 
         let nestedLink = $.find('a').eq(1);
         f.addFor( nestedLink, 'child.childrenPages', 'subchild' );

--- a/fragments/navigation/template.html
+++ b/fragments/navigation/template.html
@@ -3,7 +3,7 @@
     <a class="p-3 no-underline"></a>
     <div class="self-stretch">
       <div class="flex flex-col dropdown-list">
-        <a href="" class="p-3 no-underline" data-per-inline="subchild.title"></a>
+        <a href="" class="p-3 no-underline"></a>
       </div>
     </div>
   </div>

--- a/fragments/navigation/template.html
+++ b/fragments/navigation/template.html
@@ -3,7 +3,7 @@
     <a class="p-3 no-underline"></a>
     <div class="self-stretch">
       <div class="flex flex-col dropdown-list">
-        <a href="" class="p-3 no-underline"></a>
+        <a href="" class="p-3 no-underline" data-per-inline="subchild.title"></a>
       </div>
     </div>
   </div>

--- a/fragments/navigation/template.vue
+++ b/fragments/navigation/template.vue
@@ -8,16 +8,16 @@
             'justify-end': model.justifyitems === 'end'
         }" v-else>
       <div class="flex flex-col dropdown-container" v-for="(child, i) in model.childrenPages"
-      :key="i">
-        <a class="p-3 no-underline" v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
-        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-        v-bind:data-per-inline="`model.childrenPages.${i}.title`">{{child.title}}</a>
+      :key="child.path || i">
+        <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
+        v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
+        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'">{{child.title}}</a>
         <div class="self-stretch" v-if="child.hasChildren &amp;&amp; child.childrenPages &amp;&amp; child.childrenPages.length &gt; 0">
           <div class="flex flex-col dropdown-list">
-            <a class="p-3 no-underline" v-bind:href="subchild.path + '.html'"
-            v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-            v-bind:data-per-inline="`model.childrenPages.${i}.title`" v-for="(subchild, i) in child.childrenPages"
-            :key="i">{{subchild.title}}</a>
+            <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
+            v-bind:href="subchild.path + '.html'" v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+            v-for="(subchild, i) in child.childrenPages" :key="subchild.path || i"
+            data-per-inline="subchild.title">{{subchild.title}}</a>
           </div>
         </div>
       </div>

--- a/fragments/navigation/template.vue
+++ b/fragments/navigation/template.vue
@@ -8,16 +8,16 @@
             'justify-end': model.justifyitems === 'end'
         }" v-else>
       <div class="flex flex-col dropdown-container" v-for="(child, i) in model.childrenPages"
-      :key="child.path || i">
-        <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
-        v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
-        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'">{{child.title}}</a>
+      :key="i">
+        <a class="p-3 no-underline" v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
+        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+        v-bind:data-per-inline="`model.childrenPages.${i}.title`">{{child.title}}</a>
         <div class="self-stretch" v-if="child.hasChildren &amp;&amp; child.childrenPages &amp;&amp; child.childrenPages.length &gt; 0">
-          <div class="flex flex-col dropdown-list" v-bind:class="model.colorscheme === 'dark' ? 'theme-dark': 'theme-light'">
-            <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
-            v-bind:href="subchild.path + '.html'" v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-            v-for="(subchild, i) in child.childrenPages" :key="subchild.path || i"
-            data-per-inline="subchild.title">{{subchild.title}}</a>
+          <div class="flex flex-col dropdown-list">
+            <a class="p-3 no-underline" v-bind:href="subchild.path + '.html'"
+            v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+            v-bind:data-per-inline="`model.childrenPages.${i}.title`" v-for="(subchild, i) in child.childrenPages"
+            :key="i">{{subchild.title}}</a>
           </div>
         </div>
       </div>

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
@@ -13,7 +13,7 @@
         v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
         v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'">{{child.title}}</a>
         <div class="self-stretch" v-if="child.hasChildren &amp;&amp; child.childrenPages &amp;&amp; child.childrenPages.length &gt; 0">
-          <div class="flex flex-col dropdown-list" v-bind:class="model.colorscheme === 'dark' ? 'theme-dark': 'theme-light'">
+          <div class="flex flex-col dropdown-list">
             <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
             v-bind:href="subchild.path + '.html'" v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
             v-for="(subchild, i) in child.childrenPages" :key="subchild.path || i"

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
@@ -8,16 +8,16 @@
             'justify-end': model.justifyitems === 'end'
         }" v-else>
       <div class="flex flex-col dropdown-container" v-for="(child, i) in model.childrenPages"
-      :key="i">
-        <a class="p-3 no-underline" v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
-        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-        v-bind:data-per-inline="`model.childrenPages.${i}.title`">{{child.title}}</a>
+      :key="child.path || i">
+        <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
+        v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
+        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'">{{child.title}}</a>
         <div class="self-stretch" v-if="child.hasChildren &amp;&amp; child.childrenPages &amp;&amp; child.childrenPages.length &gt; 0">
           <div class="flex flex-col dropdown-list">
-            <a class="p-3 no-underline" v-bind:href="subchild.path + '.html'"
-            v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-            v-bind:data-per-inline="`model.childrenPages.${i}.title`" v-for="(subchild, i) in child.childrenPages"
-            :key="i">{{subchild.title}}</a>
+            <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
+            v-bind:href="subchild.path + '.html'" v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+            v-for="(subchild, i) in child.childrenPages" :key="subchild.path || i"
+            data-per-inline="subchild.title">{{subchild.title}}</a>
           </div>
         </div>
       </div>

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/navigation/template.vue
@@ -8,16 +8,16 @@
             'justify-end': model.justifyitems === 'end'
         }" v-else>
       <div class="flex flex-col dropdown-container" v-for="(child, i) in model.childrenPages"
-      :key="child.path || i">
-        <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
-        v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
-        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'">{{child.title}}</a>
+      :key="i">
+        <a class="p-3 no-underline" v-bind:href="child.childrenPages.length &gt; 0 ? false : child.path +'.html'"
+        v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+        v-bind:data-per-inline="`model.childrenPages.${i}.title`">{{child.title}}</a>
         <div class="self-stretch" v-if="child.hasChildren &amp;&amp; child.childrenPages &amp;&amp; child.childrenPages.length &gt; 0">
           <div class="flex flex-col dropdown-list">
-            <a class="p-3 no-underline" v-bind:data-per-inline="`model.childrenPages.${i}.title`"
-            v-bind:href="subchild.path + '.html'" v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
-            v-for="(subchild, i) in child.childrenPages" :key="subchild.path || i"
-            data-per-inline="subchild.title">{{subchild.title}}</a>
+            <a class="p-3 no-underline" v-bind:href="subchild.path + '.html'"
+            v-bind:class="model.colorscheme === 'dark' ? 'text-gray-200 hover:bg-gray-200 hover:text-black' : 'text-black hover:bg-black hover:text-gray-200'"
+            v-bind:data-per-inline="`model.childrenPages.${i}.title`" v-for="(subchild, i) in child.childrenPages"
+            :key="i">{{subchild.title}}</a>
           </div>
         </div>
       </div>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palette.css
@@ -209,6 +209,10 @@
   background-color: var(--text-primary-color);
 }
 
+#peregrine-app [class$="-components-navigation"] .dropdown-list {
+  background: var(--bg-primary);
+}
+
 #peregrine-app [class$="-components-tabs"] a[aria-selected="true"],
 #peregrine-app [class$="-components-tabs"] a[aria-selected="true"] * {
   color: var(--btn-primary-color);

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/dawn.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/dawn.css
@@ -148,3 +148,7 @@
   #peregrine-app .themecleanflex-components-quote {
     --border-primary-color: var(--color-accent-1-700);
   }
+
+  #peregrine-app .theme-dark[class$="-components-navigation"] a:hover{
+    color: var(--color-accent-1-700);
+  }

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/ocean.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/ocean.css
@@ -132,3 +132,7 @@
 #peregrine-app .themecleanflex-components-quote {
   --border-primary-color: var(--color-accent-1-700);
 }
+
+#peregrine-app .theme-dark[class$="-components-navigation"] a:hover{
+  color: var(--color-accent-1-700);
+}


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

#144; Adjusted multinavigation dark theme colors, that won't affect other components.

**Does this close any currently open issues?**

#144 

**Where has this been tested?**
Local. 
Now v
<img width="375" alt="Screen Shot 2020-08-11 at 11 53 07 AM" src="https://user-images.githubusercontent.com/49845255/89936932-3ad26d80-dbc9-11ea-8562-34dd3d0858ae.png">

*Browser (version):* Chrome v84
