### PR TITLE
Issues/45 - Accordion 'after-content' media mobile fixes

### DIFF
--- a/fragments/accordion/hatch.js
+++ b/fragments/accordion/hatch.js
@@ -6,7 +6,6 @@ module.exports = {
         //Header
     	f.addIf($.find('h2').first(), 'model.showtitle == \'true\'')
         f.mapField($.find('h2').first(), "model.title")
-        f.bindAttribute($.find('h2').first(), "data-per-inline", "`model.title`")
 
         //Content Container
         let containerClasses = `{

--- a/fragments/accordion/hatch.js
+++ b/fragments/accordion/hatch.js
@@ -65,11 +65,9 @@ module.exports = {
         f.bindEvent(toggle, 'click', "toggleItem(i)")
         f.bindAttribute(toggle, 'aria-expanded', "active[i] ? 'true' : 'false'")
         f.mapField(toggleText, "item.title", "model.accordiontoggle", "title")
-        f.bindAttribute(toggleText, "data-per-inline", "`model.accordiontoggle.${i}.title`")
 
         //Acocordion Item Body
         f.mapRichField($.find('div.card-content > div').first(), "item.text", "model.accordiontoggle", "text")
-        f.bindAttribute($.find('div.card-content > div').first(), 'data-per-inline', "`model.accordiontoggle.${i}.text`")
         f.bindAttribute($.find('div.card-content > div').first(), 'ref', "`cardContent${i}`")
         f.addStyle($.find('div.card-content').first(), 'height', "active[i] ? heights[i] + 'px' : '0px'")
         f.addStyle($.find('svg').first(), 'transform', "active[i] ? 'rotate(180deg)': 'rotate(0)'")

--- a/fragments/accordion/hatch.js
+++ b/fragments/accordion/hatch.js
@@ -9,6 +9,8 @@ module.exports = {
 
         //Content Container
         let containerClasses = `{
+            'flex-col': model.mediaposition === 'before',
+            'flex-col-reverse': model.mediaposition === 'after',
             'lg:flex-row': model.mediaposition === 'before',
             'lg:flex-row-reverse': model.mediaposition === 'after'
         }`
@@ -62,9 +64,11 @@ module.exports = {
         f.bindEvent(toggle, 'click', "toggleItem(i)")
         f.bindAttribute(toggle, 'aria-expanded', "active[i] ? 'true' : 'false'")
         f.mapField(toggleText, "item.title", "model.accordiontoggle", "title")
+        f.bindAttribute(toggleText, "data-per-inline", "`model.accordiontoggle.${i}.title`")
 
         //Acocordion Item Body
         f.mapRichField($.find('div.card-content > div').first(), "item.text", "model.accordiontoggle", "text")
+        f.bindAttribute($.find('div.card-content > div').first(), 'data-per-inline', "`model.accordiontoggle.${i}.text`")
         f.bindAttribute($.find('div.card-content > div').first(), 'ref', "`cardContent${i}`")
         f.addStyle($.find('div.card-content').first(), 'height', "active[i] ? heights[i] + 'px' : '0px'")
         f.addStyle($.find('svg').first(), 'transform', "active[i] ? 'rotate(180deg)': 'rotate(0)'")

--- a/fragments/accordion/hatch.js
+++ b/fragments/accordion/hatch.js
@@ -6,6 +6,7 @@ module.exports = {
         //Header
     	f.addIf($.find('h2').first(), 'model.showtitle == \'true\'')
         f.mapField($.find('h2').first(), "model.title")
+        f.bindAttribute($.find('h2').first(), "data-per-inline", "`model.title`")
 
         //Content Container
         let containerClasses = `{

--- a/fragments/accordion/template.html
+++ b/fragments/accordion/template.html
@@ -1,7 +1,7 @@
 <div class="w-full">
 	<h2 class="text-xl text-center pb-4">Toggle with media</h2>
 
-	<div class="flex flex-col -mx-3 flex-grow">
+	<div class="flex -mx-3 flex-grow">
 
 		<div class="img-wrapper px-0 md:px-3">
 			<img src="/content/themecleanflex/assets/samples/beach-bird-s-eye-view-daytime-1249586.jpg">

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -33,7 +33,7 @@
             'rounded-full': model.roundedcorners == 'full'
         }">
           <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
-          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-for="(item, i) in model.accordiontoggle" :key="item.path || i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -2,9 +2,10 @@
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
-      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
-      data-per-inline="model.title">{{model.title}}</h2>
-      <div class="flex flex-col -mx-3 flex-grow" v-bind:class="{
+      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'">{{model.title}}</h2>
+      <div class="flex -mx-3 flex-grow" v-bind:class="{
+            'flex-col': model.mediaposition === 'before',
+            'flex-col-reverse': model.mediaposition === 'after',
             'lg:flex-row': model.mediaposition === 'before',
             'lg:flex-row-reverse': model.mediaposition === 'after'
         }">
@@ -31,7 +32,7 @@
             'rounded-full': model.roundedcorners == 'full'
         }">
           <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
-          v-for="(item, i) in model.accordiontoggle" :key="item.path || i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -3,7 +3,7 @@
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
       <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
-      v-bind:data-per-inline="`model.title`">{{model.title}}</h2>
+      data-per-inline="model.title">{{model.title}}</h2>
       <div class="flex -mx-3 flex-grow" v-bind:class="{
             'flex-col': model.mediaposition === 'before',
             'flex-col-reverse': model.mediaposition === 'after',

--- a/fragments/accordion/template.vue
+++ b/fragments/accordion/template.vue
@@ -2,7 +2,8 @@
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
-      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'">{{model.title}}</h2>
+      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
+      v-bind:data-per-inline="`model.title`">{{model.title}}</h2>
       <div class="flex -mx-3 flex-grow" v-bind:class="{
             'flex-col': model.mediaposition === 'before',
             'flex-col-reverse': model.mediaposition === 'after',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -33,7 +33,7 @@
             'rounded-full': model.roundedcorners == 'full'
         }">
           <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
-          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-for="(item, i) in model.accordiontoggle" :key="item.path || i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -2,8 +2,7 @@
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
-      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
-      data-per-inline="model.title">{{model.title}}</h2>
+      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'">{{model.title}}</h2>
       <div class="flex -mx-3 flex-grow" v-bind:class="{
             'flex-col': model.mediaposition === 'before',
             'flex-col-reverse': model.mediaposition === 'after',
@@ -33,7 +32,7 @@
             'rounded-full': model.roundedcorners == 'full'
         }">
           <div class="accordion-item border-b transition-colors duration-200 ease-in-out"
-          v-for="(item, i) in model.accordiontoggle" :key="item.path || i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
+          v-for="(item, i) in model.accordiontoggle" :key="i" v-bind:id="`accordion${_uid}${parseInt(i)+1}`"
           v-bind:class="{
             'border-b border-solid border-gray-300': model.colorscheme === 'light' &amp;&amp; model.cardborder === 'true',
             'border-b border-solid border-gray-900': model.colorscheme === 'dark' &amp;&amp; model.cardborder === 'true',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -4,7 +4,9 @@
     <div class="w-full" v-else>
       <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
       data-per-inline="model.title">{{model.title}}</h2>
-      <div class="flex flex-col -mx-3 flex-grow" v-bind:class="{
+      <div class="flex -mx-3 flex-grow" v-bind:class="{
+            'flex-col': model.mediaposition === 'before',
+            'flex-col-reverse': model.mediaposition === 'after',
             'lg:flex-row': model.mediaposition === 'before',
             'lg:flex-row-reverse': model.mediaposition === 'after'
         }">

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -3,7 +3,7 @@
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
       <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
-      v-bind:data-per-inline="`model.title`">{{model.title}}</h2>
+      data-per-inline="model.title">{{model.title}}</h2>
       <div class="flex -mx-3 flex-grow" v-bind:class="{
             'flex-col': model.mediaposition === 'before',
             'flex-col-reverse': model.mediaposition === 'after',

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/accordion/template.vue
@@ -2,7 +2,8 @@
   <themecleanflex-components-block v-bind:model="model">
     <div class="p-5" v-if="isEditAndEmpty">no content defined for component</div>
     <div class="w-full" v-else>
-      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'">{{model.title}}</h2>
+      <h2 class="text-xl text-center pb-4" v-if="model.showtitle == 'true'"
+      v-bind:data-per-inline="`model.title`">{{model.title}}</h2>
       <div class="flex -mx-3 flex-grow" v-bind:class="{
             'flex-col': model.mediaposition === 'before',
             'flex-col-reverse': model.mediaposition === 'after',

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/dawn.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/dawn.css
@@ -107,13 +107,13 @@
   
   /* Individual overwrites */
   
-  #peregrine-app .themecleanflex-components-cards.theme-light .card--bg {
+  #peregrine-app [class$='components-cards'].theme-light .card--bg {
     --text-primary-color: rgba(255,255,255,0.87);
     --text-secondary-color: rgba(255,255,255,0.6);
   }
   
-  #peregrine-app .themecleanflex-components-cards.theme-dark .card--bg,
-  #peregrine-app .themecleanflex-components-accordion.theme-dark .accordion-container .bg-secondary {
+  #peregrine-app [class$='components-cards'].theme-dark .card--bg,
+  #peregrine-app [class$='components-accordion'].theme-dark .accordion-container .bg-secondary {
      /* Apply black text colour because otherwise it would render white on white */
     --text-primary-color: rgba(0,0,0,0.87);
     --text-secondary-color: rgba(0,0,0,0.6);
@@ -135,7 +135,7 @@
     --btn-primary-focus-border-color: var(--btn-focus-border-color);
   }
   
-  #peregrine-app .themecleanflex-components-accordion.theme-light .accordion-container .bg-secondary {
+  #peregrine-app [class$='components-accordion'].theme-light .accordion-container .bg-secondary {
      /* Reduce strong visual noise by removing the default primary background colour */
     --bg-secondary: rgba(255,255,255,0.6);
   }
@@ -145,6 +145,6 @@
     background: transparent;
   }
   
-  #peregrine-app .themecleanflex-components-quote {
+  #peregrine-app [class$='components-quote'] {
     --border-primary-color: var(--color-accent-1-700);
   }

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/ocean.css
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/pages/css/palettes/ocean.css
@@ -107,19 +107,19 @@
 
 /* Individual overwrites */
 
-#peregrine-app .themecleanflex-components-cards.theme-light .card--bg {
+#peregrine-app [class$='components-cards'].theme-light .card--bg {
   --text-primary-color: rgba(255,255,255,0.87);
   --text-secondary-color: rgba(255,255,255,0.6);
 }
 
-#peregrine-app .themecleanflex-components-cards.theme-dark .card--bg,
-#peregrine-app .themecleanflex-components-accordion.theme-dark .accordion-container .bg-secondary {
+#peregrine-app [class$='components-cards'].theme-dark .card--bg,
+#peregrine-app [class$='components-accordion'].theme-dark .accordion-container .bg-secondary {
    /* Apply black text colour because otherwise it would render white on white */
   --text-primary-color: rgba(0,0,0,0.87);
   --text-secondary-color: rgba(0,0,0,0.6);
 }
 
-#peregrine-app .themecleanflex-components-accordion.theme-light .accordion-container .bg-secondary {
+#peregrine-app [class$='components-accordion'].theme-light .accordion-container .bg-secondary {
    /* Reduce strong visual noise by removing the default primary background colour */
   --bg-secondary: rgba(255,255,255,0.6);
 }
@@ -129,6 +129,6 @@
   background: transparent;
 }
 
-#peregrine-app .themecleanflex-components-quote {
+#peregrine-app [class$='components-quote'] {
   --border-primary-color: var(--color-accent-1-700);
 }

--- a/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
+++ b/ui.apps/src/main/content/jcr_root/etc/felibs/themecleanflex/css/build.css
@@ -723,6 +723,10 @@ video {
   flex-direction: column;
 }
 
+.flex-col-reverse {
+  flex-direction: column-reverse;
+}
+
 .flex-wrap {
   flex-wrap: wrap;
 }


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

Accordion's 'after-content' media was not working for mobile displays. 

**Does this close any currently open issues?**

#45 

Added more to hatch.js because previously wasn't hatched.

**Where has this been tested?**
Local

<img width="451" alt="Screen Shot 2020-08-11 at 4 58 51 PM" src="https://user-images.githubusercontent.com/49845255/89960587-4a1ae080-dbf4-11ea-9104-11d2a405d9d1.png">


*Browser (version):* Chrome v84
