### PR TITLE
started new component for using external content such embedded iframes

### DIFF
--- a/core/src/main/java/com/themecleanflex/models/ExternalModel.java
+++ b/core/src/main/java/com/themecleanflex/models/ExternalModel.java
@@ -1,0 +1,78 @@
+package com.themecleanflex.models;
+
+import com.peregrine.nodetypes.models.AbstractComponent;
+import com.peregrine.nodetypes.models.IComponent;
+import com.peregrine.nodetypes.models.Container;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/*
+    //GEN[:DATA
+    {
+  "definitions": {
+    "External": {
+      "type": "object",
+      "x-type": "component",
+      "properties": {
+        "text": {
+          "type": "string",
+          "x-source": "inject",
+          "x-form-type": "texteditor"
+        }
+      }
+    }
+  },
+  "name": "External",
+  "componentPath": "themecleanflex/components/external",
+  "package": "com.themecleanflex.models",
+  "modelName": "External",
+  "classNameParent": "AbstractComponent"
+}
+//GEN]
+*/
+
+//GEN[:DEF
+@Model(
+        adaptables = Resource.class,
+        resourceType = "themecleanflex/components/external",
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
+        adapters = IComponent.class
+)
+@Exporter(
+        name = "jackson",
+        extensions = "json"
+)
+
+//GEN]
+public class ExternalModel extends AbstractComponent {
+
+    public ExternalModel(Resource r) { super(r); }
+
+    //GEN[:INJECT
+    	/* {"type":"string","x-source":"inject","x-form-type":"texteditor"} */
+	@Inject
+	private String text;
+
+
+//GEN]
+
+    //GEN[:GETTERS
+    	/* {"type":"string","x-source":"inject","x-form-type":"texteditor"} */
+	public String getText() {
+		return text;
+	}
+
+
+//GEN]
+
+    //GEN[:CUSTOMGETTERS
+    //GEN]
+
+}

--- a/fragments/external/hatch.js
+++ b/fragments/external/hatch.js
@@ -1,0 +1,5 @@
+module.exports = {
+    convert: function($, f) {
+        f.bindPath($)
+    }
+}

--- a/fragments/external/model.json
+++ b/fragments/external/model.json
@@ -1,0 +1,15 @@
+{
+  "definitions": {
+    "External": {
+      "type": "object",
+      "x-type": "component",
+      "properties": {
+        "htmlCode": {
+          "type": "string",
+          "x-source": "inject",
+          "x-form-type": "textarea"
+        }
+      }
+    }
+  }
+}

--- a/fragments/external/sample.json
+++ b/fragments/external/sample.json
@@ -1,0 +1,7 @@
+{
+  "title": "External",
+  "group": "",
+  "model": {
+    "htmlCode": "<h1>code</h1>"
+  }
+}

--- a/fragments/external/template.html
+++ b/fragments/external/template.html
@@ -1,0 +1,1 @@
+<div>external</div>

--- a/fragments/external/template.vue
+++ b/fragments/external/template.vue
@@ -1,0 +1,12 @@
+<template>
+    <div class="p-5" v-if="model.text == undefined">no content defined for component</div>
+    <div v-bind:data-per-path="model.path" v-html="model.text">
+    </div>
+</template>
+
+<script>
+    export default {
+        props: ['model']
+    }
+</script>
+

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="per:Component"
+          jcr:title="external"
+          />

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/.content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:primaryType="per:Component"
-          jcr:title="external"
+          jcr:title="External"
+          group=""
           />

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/dialog.json
@@ -1,0 +1,12 @@
+{
+    "fields":[
+        {
+            "type":"material-textarea",
+            "rows":50,
+            "placeholder":"text",
+            "label":"text",
+            "model":"text",
+            "x_form_group": "content"
+        }
+    ]
+}

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/dialog.json
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/dialog.json
@@ -4,8 +4,9 @@
             "type":"material-textarea",
             "rows":50,
             "placeholder":"text",
-            "label":"text",
+            "label":"HTML Code",
             "model":"text",
+            "hint": "Embed external code with caution",
             "x_form_group": "content"
         }
     ]

--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/template.vue
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external/template.vue
@@ -1,0 +1,14 @@
+<template>
+    <div v-bind:data-per-path="model.path" style="width:100%; padding: 6px;">
+        <div class="p-5" v-if="model.text == undefined">no content defined for component</div>
+        <div v-html="model.text" style="padding:6px;">
+        </div>
+    </div>
+</template>
+
+<script>
+    export default {
+        props: ['model']
+    }
+</script>
+


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**
Currently there is no authoring component for embedding external content from ad networks or social media.
Twitter Embed
<img width="1537" alt="Screen Shot 2021-08-06 at 11 25 59 AM" src="https://user-images.githubusercontent.com/1811207/128572508-adb63678-239c-41e0-a4ae-f949b3f40b07.png">

Youtube Embed
<img width="1537" alt="Screen Shot 2021-08-06 at 5 18 12 PM" src="https://user-images.githubusercontent.com/1811207/128572514-160d0825-9520-4973-98b9-3cb160c91c25.png">


**Does this close any currently open issues?**
No. I've mentioned the issue in the past during the water-cooler and Gaston has also faced issues embedding external content.


**Any other comments?**
I still don't have a strong grasp on the percli commands needed to create and update the components. Could not find the docs that really explain the process. So I used `percli create component external` to initialize the component sources, and updated the files under `ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/external` manually 

**Where has this been tested?**
Localhost

*Browser (version):* 
Firefox 78.12.0esr (mac)
Chrome 92.0.4515.131 (mac)