### PR TITLE
Issues/1098 make tags od based

### DIFF
--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/.content.xml
@@ -4,7 +4,9 @@
   xmlns:jcr="http://www.jcp.org/jcr/1.0"
   jcr:primaryType="per:Page"
   jcr:title="themecleanflex root object"
-  jcr:description="themecleanflex Objects Root">
+  jcr:description="themecleanflex Objects Root"
+  allowedNodeTypes="[per:ObjectDefinition]"
+>
 
   <jcr:content
     jcr:primaryType="per:PageContent"

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/.content.xml
@@ -5,7 +5,7 @@
   jcr:primaryType="per:Page"
   jcr:title="themecleanflex root object"
   jcr:description="themecleanflex Objects Root"
-  allowedNodeTypes="[per:ObjectDefinition]"
+  allowedObjects="[]"
 >
 
   <jcr:content

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/sampleFolder/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/sampleFolder/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
   jcr:primaryType="sling:OrderedFolder"
-  jcr:title="Tags Folder"
-  allowedObjects="[tag]"
+  jcr:title="Sample Folder"
+  allowedObjects="[example-form-all,example-form-contact]"
 />

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/tags/.content.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
   jcr:primaryType="sling:OrderedFolder"
-  allowedObjects="[tag]"/>
+  allowedObjects="[tag]"
+  allowedNodeTypes="[per:Tag]"
+/>

--- a/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/tags/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/content/themecleanflex/objects/tags/.content.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
   jcr:primaryType="sling:OrderedFolder"
-  allowedObjects="[tag]"
   allowedNodeTypes="[per:Tag]"
 />


### PR DESCRIPTION
<!-- Thanks for contributing to Peregrine CMS! -->

**What does this implement/fix? Explain your changes.**

Added Folder Titles and reverted back the changes for Allowed Nodetypes back to Allowed Objects

**Does this close any currently open issues?**

No

**Any other comments?**

No

**Where has this been tested?**

Chrome v. 105
